### PR TITLE
Tests for premisAgentXMLToObject.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ tox
 pytest==2.7.3
 pytest-django==2.8.0
 factory_boy==2.5.2
+mock==1.3.0

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import uuid
 
+from mock import patch
 from lxml import etree, objectify
 import pytest
 
@@ -197,3 +198,113 @@ class TestPremisEventXMLToObject:
         event = presentation.premisEventXMLToObject(tree)
 
         assert isinstance(event.event_date_time, datetime)
+
+
+@pytest.mark.django_db
+class TestPremisAgentXMLToObject:
+    identifier = 'EqLVtAeVnHoR'
+
+    @pytest.fixture
+    def agent_xml(self):
+        def xml_template(identifier):
+            xml = """<?xml version="1.0"?>
+                <premis:agent xmlns:premis="info:lc/xmlns/premis-v2">
+                  <premis:agentIdentifier>
+                    <premis:agentIdentifierValue>{identifier}</premis:agentIdentifierValue>
+                    <premis:agentIdentifierType>PES:Agent</premis:agentIdentifierType>
+                  </premis:agentIdentifier>
+                  <premis:agentName>asXbNNQgsgbS</premis:agentName>
+                  <premis:agentType>Software</premis:agentType>
+                  <premis:agentNote>This is a test Agent</premis:agentNote>
+                </premis:agent>
+            """
+            return xml.format(identifier=identifier)
+        return xml_template
+
+    def test_returns_agent(self, agent_xml):
+        xml = agent_xml(self.identifier)
+        agent = presentation.premisAgentXMLToObject(xml)
+        assert isinstance(agent, models.Agent)
+
+    @patch('premis_event_service.presentation.premisAgentXMLgetObject')
+    @patch('premis_event_service.presentation.Agent')
+    def test_creates_new_agent(self, agent_mock, get_object_mock, agent_xml):
+        xml = agent_xml(self.identifier)
+        get_object_mock.side_effect = Exception
+        presentation.premisAgentXMLToObject(xml)
+
+        assert get_object_mock.called
+        assert agent_mock.called
+
+    @patch('premis_event_service.presentation.premisAgentXMLgetObject')
+    @patch('premis_event_service.presentation.Agent')
+    def test_gets_existing_agent(self, agent_mock, get_object_mock, agent_xml):
+        xml = agent_xml(self.identifier)
+        presentation.premisAgentXMLToObject(xml)
+
+        assert get_object_mock.called
+        assert not agent_mock.called
+
+    def test_set_agent_identifier(self, agent_xml):
+        xml = agent_xml(self.identifier)
+        presentation.premisAgentXMLToObject(xml)
+        agent = presentation.premisAgentXMLToObject(xml)
+        xml_obj = objectify.fromstring(xml)
+        assert agent.agent_identifier == xml_obj.agentIdentifier.agentIdentifierValue
+
+    def test_raises_exception_when_agent_identifier_is_missing(self, agent_xml):
+        xml = agent_xml(self.identifier)
+        xml_obj = objectify.fromstring(xml)
+        del xml_obj.agentIdentifier
+
+        with pytest.raises(Exception) as e:
+            presentation.premisAgentXMLToObject(etree.tostring(xml_obj))
+
+        expected_message = "Unable to set 'agent_identifier'"
+        assert expected_message in str(e), 'The exception messages matches'
+
+    def test_sets_agent_type(self, agent_xml):
+        xml = agent_xml(self.identifier)
+        agent = presentation.premisAgentXMLToObject(xml)
+        xml_obj = objectify.fromstring(xml)
+        assert agent.agent_type == xml_obj.agentType
+
+    def test_raises_exception_when_agent_type_is_missing(self, agent_xml):
+        xml = agent_xml(self.identifier)
+        xml_obj = objectify.fromstring(xml)
+        del xml_obj.agentType
+
+        with pytest.raises(Exception) as e:
+            presentation.premisAgentXMLToObject(etree.tostring(xml_obj))
+
+        expected_message = "Unable to set 'agent_type'"
+        assert expected_message in str(e), 'The exception messages matches'
+
+    def test_sets_agent_name(self, agent_xml):
+        xml = agent_xml(self.identifier)
+        agent = presentation.premisAgentXMLToObject(xml)
+        xml_obj = objectify.fromstring(xml)
+        assert agent.agent_name == xml_obj.agentName
+
+    def test_raises_exception_when_agent_name_is_missing(self, agent_xml):
+        xml = agent_xml(self.identifier)
+        xml_obj = objectify.fromstring(xml)
+        del xml_obj.agentName
+
+        with pytest.raises(Exception) as e:
+            presentation.premisAgentXMLToObject(etree.tostring(xml_obj))
+
+        expected_message = "Unable to set 'agent_name'"
+        assert expected_message in str(e), 'The exception messages matches'
+
+    def test_sets_agent_note(self, agent_xml):
+        xml = agent_xml(self.identifier)
+        agent = presentation.premisAgentXMLToObject(xml)
+        xml_obj = objectify.fromstring(xml)
+        assert agent.agent_note == xml_obj.agentNote
+
+    def test_exception_not_raised_when_agent_note_is_missing(self, agent_xml):
+        xml = agent_xml(self.identifier)
+        xml_obj = objectify.fromstring(xml)
+        del xml_obj.agentNote
+        presentation.premisAgentXMLToObject(etree.tostring(xml_obj))

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -273,7 +273,7 @@ class TestPremisAgentXMLToObject:
             presentation.premisAgentXMLToObject(etree.tostring(xml_obj))
 
         expected_message = "Unable to set 'agent_identifier'"
-        assert expected_message in str(e), 'The exception messages matches'
+        assert expected_message in str(e), 'The exception message matches'
 
     def test_sets_agent_type(self):
         xml = self.agent_xml(self.identifier)
@@ -290,7 +290,7 @@ class TestPremisAgentXMLToObject:
             presentation.premisAgentXMLToObject(etree.tostring(xml_obj))
 
         expected_message = "Unable to set 'agent_type'"
-        assert expected_message in str(e), 'The exception messages matches'
+        assert expected_message in str(e), 'The exception message matches'
 
     def test_sets_agent_name(self):
         xml = self.agent_xml(self.identifier)
@@ -307,7 +307,7 @@ class TestPremisAgentXMLToObject:
             presentation.premisAgentXMLToObject(etree.tostring(xml_obj))
 
         expected_message = "Unable to set 'agent_name'"
-        assert expected_message in str(e), 'The exception messages matches'
+        assert expected_message in str(e), 'The exception message matches'
 
     def test_sets_agent_note(self):
         xml = self.agent_xml(self.identifier)

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -234,20 +234,20 @@ class TestPremisAgentXMLToObject:
     @patch('premis_event_service.presentation.premisAgentXMLgetObject')
     @patch('premis_event_service.presentation.Agent')
     def test_creates_new_agent(self, agent_mock, get_object_mock, agent_xml):
-        """Check that a new Agent object is created if an existing object
+        """Check that a new Agent object is created if an existing Agent
         cannot be retrieved.
         """
         xml = agent_xml(self.identifier)
 
-        # get_object_mock is the mock that is patched of premisAgentXMLgetObject.
-        # The name has changed for brevity.
+        # get_object_mock is the mock that is patched over premisAgentXMLgetObject.
+        # The name change is for brevity.
         get_object_mock.side_effect = Exception
         presentation.premisAgentXMLToObject(xml)
 
-        # Agent will be called only if the premisAgentXMLgetObject raises an
-        # exception. We will verify that both mocks have been called to assert
-        # that premisAgentXMLgetObject raised and exception and a new Agent
-        # was created.
+        # Agent will be called only if the call to premisAgentXMLgetObject
+        # raises an exception. We will verify that both mocks have been
+        # called to assert that premisAgentXMLgetObject raised and exception
+        # and a new Agent was created.
         assert get_object_mock.called
         assert agent_mock.called
 

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -204,40 +204,36 @@ class TestPremisEventXMLToObject:
 class TestPremisAgentXMLToObject:
     identifier = 'EqLVtAeVnHoR'
 
-    @pytest.fixture
-    def agent_xml(self):
-        """Agent XML Fixture.
+    def agent_xml(self, identifier):
+        """Agent XML outside the context of of a feed entry.
 
-        Returns a callable that takes the Agent identifier as an argument.
-        The callable then returns the Agent XML with the given identifier.
+        Takes an Agent identifier as a argument.
         """
-        def xml_template(identifier):
-            xml = """<?xml version="1.0"?>
-                <premis:agent xmlns:premis="info:lc/xmlns/premis-v2">
-                  <premis:agentIdentifier>
-                    <premis:agentIdentifierValue>{identifier}</premis:agentIdentifierValue>
-                    <premis:agentIdentifierType>PES:Agent</premis:agentIdentifierType>
-                  </premis:agentIdentifier>
-                  <premis:agentName>asXbNNQgsgbS</premis:agentName>
-                  <premis:agentType>Software</premis:agentType>
-                  <premis:agentNote>This is a test Agent</premis:agentNote>
-                </premis:agent>
-            """
-            return xml.format(identifier=identifier)
-        return xml_template
+        xml = """<?xml version="1.0"?>
+            <premis:agent xmlns:premis="info:lc/xmlns/premis-v2">
+              <premis:agentIdentifier>
+                <premis:agentIdentifierValue>{identifier}</premis:agentIdentifierValue>
+                <premis:agentIdentifierType>PES:Agent</premis:agentIdentifierType>
+              </premis:agentIdentifier>
+              <premis:agentName>asXbNNQgsgbS</premis:agentName>
+              <premis:agentType>Software</premis:agentType>
+              <premis:agentNote>This is a test Agent</premis:agentNote>
+            </premis:agent>
+        """
+        return xml.format(identifier=identifier)
 
-    def test_returns_agent(self, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_returns_agent(self):
+        xml = self.agent_xml(self.identifier)
         agent = presentation.premisAgentXMLToObject(xml)
         assert isinstance(agent, models.Agent)
 
     @patch('premis_event_service.presentation.premisAgentXMLgetObject')
     @patch('premis_event_service.presentation.Agent')
-    def test_creates_new_agent(self, agent_mock, get_object_mock, agent_xml):
+    def test_creates_new_agent(self, agent_mock, get_object_mock):
         """Check that a new Agent object is created if an existing Agent
         cannot be retrieved.
         """
-        xml = agent_xml(self.identifier)
+        xml = self.agent_xml(self.identifier)
 
         # get_object_mock is the mock that is patched over premisAgentXMLgetObject.
         # The name change is for brevity.
@@ -253,8 +249,8 @@ class TestPremisAgentXMLToObject:
 
     @patch('premis_event_service.presentation.premisAgentXMLgetObject')
     @patch('premis_event_service.presentation.Agent')
-    def test_gets_existing_agent(self, agent_mock, get_object_mock, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_gets_existing_agent(self, agent_mock, get_object_mock):
+        xml = self.agent_xml(self.identifier)
         presentation.premisAgentXMLToObject(xml)
 
         assert get_object_mock.called
@@ -262,15 +258,15 @@ class TestPremisAgentXMLToObject:
         # retrieved.
         assert not agent_mock.called
 
-    def test_sets_agent_identifier(self, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_sets_agent_identifier(self):
+        xml = self.agent_xml(self.identifier)
         presentation.premisAgentXMLToObject(xml)
         agent = presentation.premisAgentXMLToObject(xml)
         xml_obj = objectify.fromstring(xml)
         assert agent.agent_identifier == xml_obj.agentIdentifier.agentIdentifierValue
 
-    def test_raises_exception_when_agent_identifier_is_missing(self, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_raises_exception_when_agent_identifier_is_missing(self):
+        xml = self.agent_xml(self.identifier)
         xml_obj = objectify.fromstring(xml)
         del xml_obj.agentIdentifier
 
@@ -280,14 +276,14 @@ class TestPremisAgentXMLToObject:
         expected_message = "Unable to set 'agent_identifier'"
         assert expected_message in str(e), 'The exception messages matches'
 
-    def test_sets_agent_type(self, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_sets_agent_type(self):
+        xml = self.agent_xml(self.identifier)
         agent = presentation.premisAgentXMLToObject(xml)
         xml_obj = objectify.fromstring(xml)
         assert agent.agent_type == xml_obj.agentType
 
-    def test_raises_exception_when_agent_type_is_missing(self, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_raises_exception_when_agent_type_is_missing(self):
+        xml = self.agent_xml(self.identifier)
         xml_obj = objectify.fromstring(xml)
         del xml_obj.agentType
 
@@ -297,14 +293,14 @@ class TestPremisAgentXMLToObject:
         expected_message = "Unable to set 'agent_type'"
         assert expected_message in str(e), 'The exception messages matches'
 
-    def test_sets_agent_name(self, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_sets_agent_name(self):
+        xml = self.agent_xml(self.identifier)
         agent = presentation.premisAgentXMLToObject(xml)
         xml_obj = objectify.fromstring(xml)
         assert agent.agent_name == xml_obj.agentName
 
-    def test_raises_exception_when_agent_name_is_missing(self, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_raises_exception_when_agent_name_is_missing(self):
+        xml = self.agent_xml(self.identifier)
         xml_obj = objectify.fromstring(xml)
         del xml_obj.agentName
 
@@ -314,14 +310,14 @@ class TestPremisAgentXMLToObject:
         expected_message = "Unable to set 'agent_name'"
         assert expected_message in str(e), 'The exception messages matches'
 
-    def test_sets_agent_note(self, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_sets_agent_note(self):
+        xml = self.agent_xml(self.identifier)
         agent = presentation.premisAgentXMLToObject(xml)
         xml_obj = objectify.fromstring(xml)
         assert agent.agent_note == xml_obj.agentNote
 
-    def test_exception_not_raised_when_agent_note_is_missing(self, agent_xml):
-        xml = agent_xml(self.identifier)
+    def test_exception_not_raised_when_agent_note_is_missing(self):
+        xml = self.agent_xml(self.identifier)
         xml_obj = objectify.fromstring(xml)
         del xml_obj.agentNote
         presentation.premisAgentXMLToObject(etree.tostring(xml_obj))

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -260,7 +260,6 @@ class TestPremisAgentXMLToObject:
 
     def test_sets_agent_identifier(self):
         xml = self.agent_xml(self.identifier)
-        presentation.premisAgentXMLToObject(xml)
         agent = presentation.premisAgentXMLToObject(xml)
         xml_obj = objectify.fromstring(xml)
         assert agent.agent_identifier == xml_obj.agentIdentifier.agentIdentifierValue

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -206,6 +206,11 @@ class TestPremisAgentXMLToObject:
 
     @pytest.fixture
     def agent_xml(self):
+        """Agent XML Fixture.
+
+        Returns a callable that takes the Agent identifier as an argument.
+        The callable then returns the Agent XML with the given identifier.
+        """
         def xml_template(identifier):
             xml = """<?xml version="1.0"?>
                 <premis:agent xmlns:premis="info:lc/xmlns/premis-v2">
@@ -229,10 +234,20 @@ class TestPremisAgentXMLToObject:
     @patch('premis_event_service.presentation.premisAgentXMLgetObject')
     @patch('premis_event_service.presentation.Agent')
     def test_creates_new_agent(self, agent_mock, get_object_mock, agent_xml):
+        """Check that a new Agent object is created if an existing object
+        cannot be retrieved.
+        """
         xml = agent_xml(self.identifier)
+
+        # get_object_mock is the mock that is patched of premisAgentXMLgetObject.
+        # The name has changed for brevity.
         get_object_mock.side_effect = Exception
         presentation.premisAgentXMLToObject(xml)
 
+        # Agent will be called only if the premisAgentXMLgetObject raises an
+        # exception. We will verify that both mocks have been called to assert
+        # that premisAgentXMLgetObject raised and exception and a new Agent
+        # was created.
         assert get_object_mock.called
         assert agent_mock.called
 
@@ -243,9 +258,11 @@ class TestPremisAgentXMLToObject:
         presentation.premisAgentXMLToObject(xml)
 
         assert get_object_mock.called
+        # If agent_mock was not called, we know that an existing Agent was
+        # retrieved.
         assert not agent_mock.called
 
-    def test_set_agent_identifier(self, agent_xml):
+    def test_sets_agent_identifier(self, agent_xml):
         xml = agent_xml(self.identifier)
         presentation.premisAgentXMLToObject(xml)
         agent = presentation.premisAgentXMLToObject(xml)
@@ -308,3 +325,5 @@ class TestPremisAgentXMLToObject:
         xml_obj = objectify.fromstring(xml)
         del xml_obj.agentNote
         presentation.premisAgentXMLToObject(etree.tostring(xml_obj))
+        # No assertions here. We only want to make sure that no exceptions
+        # were raised.


### PR DESCRIPTION
Partially completes #27 

I reworked how the XML is used in the tests. Now that we have more tests that need to share these resources, many of the XML 'fixtures' will be reworked in a similar fashion, and they will likely be relocated to a centrally located module.