### PR TITLE
Remove pattern and convert to named urls.

### DIFF
--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -44,7 +44,7 @@ class Agent(models.Model):
         return self.agent_name
 
     def get_absolute_url(self):
-        return reverse('premis_event_service.views.humanAgent', args=[self.agent_identifier])
+        return reverse('agent-detail', args=[self.agent_identifier])
 
     class Meta:
         ordering = ['agent_name']

--- a/premis_event_service/urls.py
+++ b/premis_event_service/urls.py
@@ -1,30 +1,20 @@
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    from django.conf.urls.defaults import *  # In case of Django<=1.3
+from django.conf.urls import url
+from . import views
 
-urlpatterns = patterns(
-    'premis_event_service.views',
-    # begin CODA Family url structure >
-    (r'^APP/$', 'app'),
-    # node urls
-    # (r'^APP/node/$', 'node'),
-    # (r'^APP/node/(?P<identifier>.+?)/$', 'node'),
-    # event urls
-    (r'^APP/event/$', 'app_event'),
-    (r'^APP/event/(?P<identifier>.+?)/$', 'app_event'),
-    # agent urls
-    (r'^APP/agent/$', 'app_agent'),
-    (r'^APP/agent/(?P<identifier>.+?)/$', 'app_agent'),
-    # html view urls
-    (r'^event/$', 'recent_event_list'),
-    (r'^event/search/$', 'event_search'),
-    (r'^event/search.json$', 'json_event_search'),
-    (r'^event/find/(?P<linked_identifier>.+?)/(?P<event_type>.+?)?/$', 'findEvent'),
-    (r'^event/(?P<identifier>.+?)/$', 'humanEvent'),
-    (r'^agent/$', 'humanAgent'),
-    (r'^agent/(?P<identifier>.+?).xml$', 'agentXML'),
-    (r'^agent/(?P<identifier>.+?).premis.xml$', 'agentXML'),
-    (r'^agent/(?P<identifier>.+?).json$', 'json_agent'),
-    (r'^agent/(?P<identifier>.+?)/$', 'humanAgent'),
-)
+urlpatterns = [
+    url(r'^APP/$', views.app, name='app'),
+    url(r'^APP/event/$', views.app_event, name='app-event'),
+    url(r'^APP/event/(?P<identifier>.+?)/$', views.app_event, name='app-event-detail'),
+    url(r'^APP/agent/$', views.app_agent, name='app-agent'),
+    url(r'^APP/agent/(?P<identifier>.+?)/$', views.app_agent, name='app-agent-detail'),
+    url(r'^event/$', views.recent_event_list, name='event-list'),
+    url(r'^event/search/$', views.event_search, name='event-search'),
+    url(r'^event/search.json$', views.json_event_search, name='event-search-json'),
+    url(r'^event/find/(?P<linked_identifier>.+?)/(?P<event_type>.+?)?/$', views.findEvent, name='find-event'),
+    url(r'^event/(?P<identifier>.+?)/$', views.humanEvent, name='event-detail'),
+    url(r'^agent/$', views.humanAgent, name='agent-list'),
+    url(r'^agent/(?P<identifier>.+?).xml$', views.agentXML, name='agent-detail-xml'),
+    url(r'^agent/(?P<identifier>.+?).premis.xml$', views.agentXML, name='agent-detail-premis-xml'),
+    url(r'^agent/(?P<identifier>.+?).json$', views.json_agent, name='agent-detail-json'),
+    url(r'^agent/(?P<identifier>.+?)/$', views.humanAgent, name='agent-detail'),
+]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -69,7 +69,7 @@ def test_humanAgent_returns_all_agents(client):
 def test_humanAgent_with_identifier(client):
     agent = factories.AgentFactory.create()
     response = client.get(
-            reverse('premis_event_service.views.humanAgent', args=[agent.agent_identifier]))
+            reverse('agent-detail', args=[agent.agent_identifier]))
     context_agent = response.context[-1]['agents'][0]
     assert agent.agent_identifier == context_agent['agent_identifier']
 
@@ -85,7 +85,7 @@ def test_recent_event_list_context(client):
     """Test the Events in the response context."""
     num_events = 30
     factories.EventFactory.create_batch(num_events)
-    response = client.get(reverse('premis_event_service.views.recent_event_list'))
+    response = client.get(reverse('event-list'))
 
     context = response.context[-1]
     assert len(context['entries']) == 10
@@ -625,7 +625,7 @@ class TestEventSearch:
     def test_results_per_page(self, client):
         factories.EventFactory.create_batch(self.RESULTS_PER_PAGE * 3)
 
-        url = reverse('premis_event_service.views.event_search')
+        url = reverse('event-search')
         response = client.get(url)
 
         context = response.context[-1]
@@ -637,7 +637,7 @@ class TestEventSearch:
         event = factories.EventFactory.create(event_date_time=timezone.now())
 
         query_string = '?start_date=01/31/2015'
-        url = reverse('premis_event_service.views.event_search')
+        url = reverse('event-search')
         response = client.get(url + query_string)
 
         assert self.response_has_event(response, event)
@@ -648,7 +648,7 @@ class TestEventSearch:
         event = factories.EventFactory.create(event_date_time=datetime_obj)
 
         query_string = '?end_date=01/31/2015'
-        url = reverse('premis_event_service.views.event_search')
+        url = reverse('event-search')
         response = client.get(url + query_string)
 
         assert self.response_has_event(response, event)
@@ -660,7 +660,7 @@ class TestEventSearch:
         linking_object = event.linking_objects.first()
 
         query_string = '?linked_object_id={0}'.format(linking_object.object_identifier)
-        url = reverse('premis_event_service.views.event_search')
+        url = reverse('event-search')
         response = client.get(url + query_string)
 
         assert self.response_has_event(response, event)
@@ -671,7 +671,7 @@ class TestEventSearch:
         event = factories.EventFactory.create(event_outcome=event_outcome)
 
         query_string = '?outcome={0}'.format(event_outcome)
-        url = reverse('premis_event_service.views.event_search')
+        url = reverse('event-search')
         response = client.get(url + query_string)
 
         assert self.response_has_event(response, event)
@@ -682,7 +682,7 @@ class TestEventSearch:
         event = factories.EventFactory.create(event_type=event_type)
 
         query_string = '?event_type={0}'.format(event_type)
-        url = reverse('premis_event_service.views.event_search')
+        url = reverse('event-search')
         response = client.get(url + query_string)
 
         assert self.response_has_event(response, event)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'', include('premis_event_service.urls')),
     url(r'^admin/', include(admin.site.urls)),
-)
+]


### PR DESCRIPTION
Fixes #23 

This upgrades the test and application urls, and all calls to `reverse`. All of the `url` template tags are still looking up the url via the Python path the view. 