### PR TITLE
Add a MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+recursive-include premis_event_service/templates * 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
 README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 
@@ -15,9 +15,8 @@ install_requires = [
 setup(
     name="django-premis-event-service",
     version="1.0.0",
-    packages=find_packages(),
+    packages=['premis_event_service'],
     include_package_data=True,
-    package_data={'': ['*.html']},
     license="BSD",
     description="A Django application for storing and querying PREMIS Events",
     long_description=README,


### PR DESCRIPTION
This will allow additional non-python files into the distribution, such
as `premis_event_service/templates/*.html`.