### PR TITLE
Refactor Event Search

### DIFF
--- a/premis_event_service/forms.py
+++ b/premis_event_service/forms.py
@@ -7,7 +7,7 @@ EVENT_TYPE_CHOICES = settings.EVENT_TYPE_CHOICES
 
 
 class EventSearchForm(forms.Form):
-    outcome = forms.ChoiceField(
+    event_outcome = forms.ChoiceField(
         widget=forms.Select(
             attrs={
                 'id': 'prependedInput',

--- a/premis_event_service/forms.py
+++ b/premis_event_service/forms.py
@@ -8,52 +8,25 @@ EVENT_TYPE_CHOICES = settings.EVENT_TYPE_CHOICES
 
 class EventSearchForm(forms.Form):
     event_outcome = forms.ChoiceField(
-        widget=forms.Select(
-            attrs={
-                'id': 'prependedInput',
-                'class': 'input-small',
-            }
-        ),
+        widget=forms.Select(attrs={'id': 'prependedInput', 'class': 'input-small'}),
         choices=OUTCOME_CHOICES,
         required=False)
 
     event_type = forms.ChoiceField(
-        widget=forms.Select(
-            attrs={
-                'id': 'prependedInput',
-                'class': 'input-medium',
-            }
-        ),
+        widget=forms.Select(attrs={'id': 'prependedInput', 'class': 'input-medium'}),
         choices=EVENT_TYPE_CHOICES,
         required=False)
 
     start_date = forms.DateField(
-        widget=forms.DateInput(
-            attrs={
-                'id': 'startdatepicker',
-                'placeholder': 'Start Date',
-                'class': 'input-small',
-            }
-        ),
+        widget=forms.DateInput(attrs={'id': 'startdatepicker', 'placeholder': 'Start Date', 'class': 'input-small'}),  # noqa
         required=False)
 
     end_date = forms.DateField(
-        widget=forms.DateInput(
-            attrs={
-                'id': 'enddatepicker',
-                'placeholder': 'End Date',
-                'class': 'input-small',
-            }
-        ),
+        widget=forms.DateInput(attrs={'id': 'enddatepicker', 'placeholder': 'End Date', 'class': 'input-small'}),  # noqa
         required=False)
 
     linked_object_id = forms.CharField(
-        widget=forms.TextInput(
-            attrs={
-                'placeholder': 'Linked Object ID',
-                'class': 'input-medium',
-            }
-        ),
+        widget=forms.TextInput(attrs={'placeholder': 'Linked Object ID', 'class': 'input-medium'}),
         max_length=20,
-        required=False,
-    )
+        required=False)
+

--- a/premis_event_service/forms.py
+++ b/premis_event_service/forms.py
@@ -15,8 +15,8 @@ class EventSearchForm(forms.Form):
             }
         ),
         choices=OUTCOME_CHOICES,
+        required=False)
 
-    )
     event_type = forms.ChoiceField(
         widget=forms.Select(
             attrs={
@@ -25,7 +25,8 @@ class EventSearchForm(forms.Form):
             }
         ),
         choices=EVENT_TYPE_CHOICES,
-    )
+        required=False)
+
     start_date = forms.DateField(
         widget=forms.DateInput(
             attrs={
@@ -33,8 +34,9 @@ class EventSearchForm(forms.Form):
                 'placeholder': 'Start Date',
                 'class': 'input-small',
             }
-        )
-    )
+        ),
+        required=False)
+
     end_date = forms.DateField(
         widget=forms.DateInput(
             attrs={
@@ -42,8 +44,9 @@ class EventSearchForm(forms.Form):
                 'placeholder': 'End Date',
                 'class': 'input-small',
             }
-        )
-    )
+        ),
+        required=False)
+
     linked_object_id = forms.CharField(
         widget=forms.TextInput(
             attrs={
@@ -52,4 +55,5 @@ class EventSearchForm(forms.Form):
             }
         ),
         max_length=20,
+        required=False,
     )

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -75,10 +75,35 @@ class LinkObject(models.Model):
         return self.object_identifier
 
 
+class EventManager(models.Manager):
+
+    def search(self, **kwargs):
+        start_date = kwargs.get('start_date')
+        end_date = kwargs.get('end_date')
+        outcome = kwargs.get('event_outcome')
+        event_type = kwargs.get('event_type')
+        linked_object_id = kwargs.get('linked_object_id')
+
+        events = Event.objects.all().order_by('-event_date_time')
+
+        # Filter based on the the supplied the arguments.
+        events = events.filter(event_date_time__gte=start_date) if start_date else events
+        events = events.filter(event_date_time__lte=end_date) if end_date else events
+        events = events.filter(event_outcome=outcome) if outcome else events
+        events = events.filter(event_type=event_type) if event_type else events
+
+        if linked_object_id:
+            events = events.filter(linking_objects__object_identifier__icontains=linked_object_id)
+
+        return events
+
+
 class Event(models.Model):
     """
     Holds all data for the events, along with the linking objects ids
     """
+
+    objects = EventManager()
 
     event_identifier = models.CharField(
         primary_key=True,

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -1,9 +1,5 @@
-from django.db import models
 from django.core.urlresolvers import reverse
-from django.conf import settings
-from django.forms.extras.widgets import SelectDateWidget
-from django.forms.fields import DateField, ChoiceField, MultipleChoiceField
-from django import forms
+from django.db import models
 
 
 # construct choices for the agent type
@@ -78,13 +74,27 @@ class LinkObject(models.Model):
 class EventManager(models.Manager):
 
     def search(self, **kwargs):
+        """Filter the Events based on
+           - A start_date less than an event_date_time
+           - An end_date greater than an event_date_time
+           - An event_outcome
+           - An event_type
+           - A related LinkObject.object_identifier
+
+        Arguments:
+            start_date (optional) - datetime
+            end_date (optional) - datetime
+            event_outcome (optional) - string
+            event_type (optional) - string
+            linked_object_id (optional) - string
+        """
         start_date = kwargs.get('start_date')
         end_date = kwargs.get('end_date')
         outcome = kwargs.get('event_outcome')
         event_type = kwargs.get('event_type')
         linked_object_id = kwargs.get('linked_object_id')
 
-        events = Event.objects.all().order_by('-event_date_time')
+        events = self.get_queryset().order_by('-event_date_time')
 
         # Filter based on the the supplied the arguments.
         events = events.filter(event_date_time__gte=start_date) if start_date else events
@@ -93,7 +103,7 @@ class EventManager(models.Manager):
         events = events.filter(event_type=event_type) if event_type else events
 
         if linked_object_id:
-            events = events.filter(linking_objects__object_identifier__icontains=linked_object_id)
+            events = events.filter(linking_objects__object_identifier=linked_object_id)
 
         return events
 

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -96,7 +96,7 @@ class EventManager(models.Manager):
 
         events = self.get_queryset().order_by('-event_date_time')
 
-        # Filter based on the the supplied the arguments.
+        # Filter based on the supplied the arguments.
         events = events.filter(event_date_time__gte=start_date) if start_date else events
         events = events.filter(event_date_time__lte=end_date) if end_date else events
         events = events.filter(event_outcome=outcome) if outcome else events

--- a/premis_event_service/templates/premis_event_service/search.html
+++ b/premis_event_service/templates/premis_event_service/search.html
@@ -62,7 +62,7 @@
                     <i class="icon-asterisk"></i> {{ entry.event_type }}
                 </td>
                 <td>
-                    {% for lo in entry.linking_objects.values %}<i class="icon-link"></i> <a href='http://{{ request.META.HTTP_HOST }}/bag/{{ lo.object_identifier }}'>{{ lo.object_identifier }}</a>{% endfor %}
+                    {% for lo in entry.linking_objects.all %}<i class="icon-link"></i> <a href='http://{{ request.META.HTTP_HOST }}/bag/{{ lo.object_identifier }}'>{{ lo.object_identifier }}</a>{% endfor %}
                 </td>
                 <td>
                     <span title="{{ entry.entry_outcome }}" class="disabled btn btn-block btn-mini btn-{{ entry.is_good|yesno:"success,danger" }}">{{ entry.event_outcome|slice:"53:" }}</span>

--- a/premis_event_service/templates/premis_event_service/search.html
+++ b/premis_event_service/templates/premis_event_service/search.html
@@ -71,18 +71,17 @@
         {% endfor %}
     </table>
 {% endif %}
-
 {% if entries.paginator.num_pages > 1 %}
     <div class="pagination pagination-centered">
         <ul>
             {% if entries.number != 1 %}
-                <li><a href="?page=1&amp;outcome={{ outcome|urlencode }}&amp;event_type={{ event_type|urlencode }}&amp;start_date={{ start_date|date:"m/d/Y" }}&amp;end_date={{ end_date|date:"m/d/Y" }}&amp;linked_object_id={{ linking_object_id|urlencode }}">first</a></li>
+                <li><a href="?page=1&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">first</a></li>
             {% else %}
                 <li class="disabled"><span>first</span></li>
             {% endif %}
 
             {% if entries.has_previous %}
-                <li><a href="?page={{ entries.previous_page_number }}&amp;outcome={{ outcome|urlencode }}&amp;event_type={{ event_type|urlencode }}&amp;start_date={{ start_date|date:"m/d/Y" }}&amp;end_date={{ end_date|date:"m/d/Y" }}&amp;linked_object_id={{ linking_object_id|urlencode }}">prev</a></li>
+                <li><a href="?page={{ entries.previous_page_number }}&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">prev</a></li>
             {% else %}
                 <li class="disabled"><span>prev</span></li>
             {% endif %}
@@ -93,7 +92,7 @@
 
                 {% else %} {% if page > entries.number|add:"-6" and page < entries.number|add:"6"  %}
                     <li>
-                        <a href="?page={{ page }}&amp;outcome={{ outcome|urlencode }}&amp;event_type={{ event_type|urlencode }}&amp;start_date={{ start_date|date:"m/d/Y" }}&amp;end_date={{ end_date|date:"m/d/Y" }}&amp;linked_object_id={{ linking_object_id|urlencode }}">
+                        <a href="?page={{ page }}&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">
                             {{ page }}
                         </a>
                     </li>
@@ -101,13 +100,13 @@
             {% endfor %}
 
             {% if entries.has_next %}
-                <li><a href="?page={{ entries.next_page_number }}&amp;outcome={{ outcome|urlencode }}&amp;event_type={{ event_type|urlencode }}&amp;start_date={{ start_date|date:"m/d/Y" }}&amp;end_date={{ end_date|date:"m/d/Y" }}&amp;linked_object_id={{ linking_object_id|urlencode }}">next</a></li>
+                <li><a href="?page={{ entries.next_page_number }}&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">next</a></li>
             {% else %}
                 <li class="disabled"><span>next</span></li>
             {% endif %}
 
             {% if entries.number != entries.paginator.num_pages %}
-                <li><a href="?page={{ entries.paginator.num_pages }}&amp;outcome={{ outcome|urlencode }}&amp;event_type={{ event_type|urlencode }}&amp;start_date={{ start_date|date:"m/d/Y" }}&amp;end_date={{ end_date|date:"m/d/Y" }}&amp;linked_object_id={{ linking_object_id|urlencode }}">last</a></li>
+                <li><a href="?page={{ entries.paginator.num_pages }}&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">last</a></li>
             {% else %}
                 <li class="disabled"><span>last</span></li>
             {% endif %}

--- a/premis_event_service/templates/premis_event_service/search.html
+++ b/premis_event_service/templates/premis_event_service/search.html
@@ -13,8 +13,8 @@
 <form action = "./" class="pagination-centered well" method="get">
     <div class="control-group">
         <div class="input-prepend">
-            <span class='add-on'>{{ search_form.outcome.label }}</span>
-            {{ search_form.outcome }}
+            <span class='add-on'>{{ search_form.event_outcome.label }}</span>
+            {{ search_form.event_outcome }}
         </div>
         <div class="input-prepend">
             <span class='add-on'>{{ search_form.event_type.label|title }}</span>
@@ -75,13 +75,13 @@
     <div class="pagination pagination-centered">
         <ul>
             {% if entries.number != 1 %}
-                <li><a href="?page=1&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">first</a></li>
+                <li><a href="?page=1&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">first</a></li>
             {% else %}
                 <li class="disabled"><span>first</span></li>
             {% endif %}
 
             {% if entries.has_previous %}
-                <li><a href="?page={{ entries.previous_page_number }}&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">prev</a></li>
+                <li><a href="?page={{ entries.previous_page_number }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">prev</a></li>
             {% else %}
                 <li class="disabled"><span>prev</span></li>
             {% endif %}
@@ -92,7 +92,7 @@
 
                 {% else %} {% if page > entries.number|add:"-6" and page < entries.number|add:"6"  %}
                     <li>
-                        <a href="?page={{ page }}&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">
+                        <a href="?page={{ page }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">
                             {{ page }}
                         </a>
                     </li>
@@ -100,13 +100,13 @@
             {% endfor %}
 
             {% if entries.has_next %}
-                <li><a href="?page={{ entries.next_page_number }}&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">next</a></li>
+                <li><a href="?page={{ entries.next_page_number }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">next</a></li>
             {% else %}
                 <li class="disabled"><span>next</span></li>
             {% endif %}
 
             {% if entries.number != entries.paginator.num_pages %}
-                <li><a href="?page={{ entries.paginator.num_pages }}&amp;outcome={{ request.GET.outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">last</a></li>
+                <li><a href="?page={{ entries.paginator.num_pages }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">last</a></li>
             {% else %}
                 <li class="disabled"><span>last</span></li>
             {% endif %}

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -123,7 +123,7 @@ def event_search(request):
 
     start_date = data.get('start_date')
     end_date = data.get('end_date')
-    outcome = data.get('outcome')
+    outcome = data.get('event_outcome')
     event_type = data.get('event_type')
     linked_object = data.get('linked_object_id')
 

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -121,20 +121,7 @@ def event_search(request):
     form = EventSearchForm(request.GET)
     data = form.cleaned_data if form.is_valid() else {}
 
-    start_date = data.get('start_date')
-    end_date = data.get('end_date')
-    outcome = data.get('event_outcome')
-    event_type = data.get('event_type')
-    linked_object = data.get('linked_object_id')
-
-    events = Event.objects.all().order_by('-event_date_time')
-    events = events.filter(event_date_time__gte=start_date) if start_date else events
-    events = events.filter(event_date_time__lte=end_date) if end_date else events
-    events = events.filter(event_outcome=outcome) if outcome else events
-    events = events.filter(event_type=event_type) if event_type else events
-
-    if linked_object:
-        events = events.filter(linking_objects__object_identifier__icontains=linked_object)
+    events = Event.objects.search(**data)
 
     paginated_entries = paginate_entries(request, events, num_per_page=20)
     context = {'search_form': form, 'entries': paginated_entries}

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -25,8 +25,11 @@ EVENT_UPDATE_TRANSLATION_DICT = translateDict
 
 XML_HEADER = "<?xml version=\"1.0\"?>\n%s"
 
-# Get a request's body (POST data). Works with all Django versions.
-get_request_body = lambda r: getattr(r, 'body', getattr(r, 'raw_post_data', ''))
+
+def get_request_body(request):
+    """Get a request's body (POST data). Works with all Django versions."""
+    return getattr(request, 'body', getattr(request, 'raw_post_data', ''))
+
 
 def app(request):
     """

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -1,24 +1,23 @@
-import uuid
-import re
-import urllib
 import datetime
 import json
-from lxml import etree
+import urllib
 
-from django.http import HttpResponse, HttpResponseBadRequest, \
-    HttpResponseNotFound
-from django.shortcuts import render_to_response, get_object_or_404
+from codalib.bagatom import (makeObjectFeed, addObjectFromXML,
+                             updateObjectFromXML, wrapAtom, makeServiceDocXML)
 from django.conf import settings
 from django.core.paginator import Paginator
+from django.http import (HttpResponse, HttpResponseBadRequest,
+                         HttpResponseNotFound)
+from django.shortcuts import render_to_response, get_object_or_404
 from django.template.context import RequestContext
+from lxml import etree
 
-from codalib.bagatom import makeObjectFeed, addObjectFromXML, \
-    updateObjectFromXML, wrapAtom, makeServiceDocXML
-from presentation import premisEventXMLToObject, premisEventXMLgetObject, \
-    premisAgentXMLToObject, objectToPremisEventXML, objectToPremisAgentXML, \
-    objectToAgentXML, translateDict
-from .models import Event, Agent, AGENT_TYPE_CHOICES
 from .forms import EventSearchForm
+from .models import Event, Agent, AGENT_TYPE_CHOICES
+from .presentation import (premisEventXMLToObject, premisEventXMLgetObject,
+                           premisAgentXMLToObject, objectToPremisEventXML,
+                           objectToPremisAgentXML, objectToAgentXML,
+                           translateDict)
 
 
 MAINTENANCE_MSG = settings.MAINTENANCE_MSG

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -118,10 +118,12 @@ def event_search(request):
     form = EventSearchForm(request.GET)
     data = form.cleaned_data if form.is_valid() else {}
 
-    events = Event.objects.search(**data)
-    results = paginate_entries(request, events)
+    events = (Event.objects.search(**data)
+                           .prefetch_related('linking_objects'))
 
+    results = paginate_entries(request, events)
     context = {'search_form': form, 'entries': results}
+
     return render(request, 'premis_event_service/search.html', context)
 
 

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -125,23 +125,16 @@ def event_search(request):
     end_date = data.get('end_date')
     outcome = data.get('outcome')
     event_type = data.get('event_type')
+    linked_object = data.get('linked_object_id')
 
     events = Event.objects.all()
-    events = Event.objects.filter(event_date_time__gte=start_date) if start_date else events
-    events = Event.objects.filter(event_date_time__lte=end_date) if end_date else events
-    events = Event.objects.filter(event_outcome=outcome) if outcome else events
-    events = Event.objects.filter(event_type=event_type) if event_type else events
+    events = events.filter(event_date_time__gte=start_date) if start_date else events
+    events = events.filter(event_date_time__lte=end_date) if end_date else events
+    events = events.filter(event_outcome=outcome) if outcome else events
+    events = events.filter(event_type=event_type) if event_type else events
 
-    if request.GET.get('linked_object_id'):
-        linking_object_id = request.GET.get('linked_object_id').strip()
-
-        if ARK_ID_REGEX.match(linking_object_id):
-            events = events.filter(linking_objects__object_identifier=linking_object_id)
-
-        elif ARK_ID_REGEX.match("ark:/67531/%s" % linking_object_id):
-            linking_object_id = "ark:/67531/%s" % linking_object_id
-            events = events.filter(
-                linking_objects__object_identifier=linking_object_id)
+    if linked_object:
+        events = events.filter(linking_objects__object_identifier__icontains=linked_object)
 
     paginated_entries = paginate_entries(request, events, num_per_page=20)
     context = {'search_form': form, 'entries': paginated_entries}

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -127,7 +127,7 @@ def event_search(request):
     event_type = data.get('event_type')
     linked_object = data.get('linked_object_id')
 
-    events = Event.objects.all()
+    events = Event.objects.all().order_by('-event_date_time')
     events = events.filter(event_date_time__gte=start_date) if start_date else events
     events = events.filter(event_date_time__lte=end_date) if end_date else events
     events = events.filter(event_outcome=outcome) if outcome else events

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -20,22 +20,10 @@ from presentation import premisEventXMLToObject, premisEventXMLgetObject, \
 from .models import Event, Agent, AGENT_TYPE_CHOICES
 from .forms import EventSearchForm
 
+
 MAINTENANCE_MSG = settings.MAINTENANCE_MSG
 EVENT_UPDATE_TRANSLATION_DICT = translateDict
-ISO8601Pattern = r"(?P<year>\d\d\d\d)(-(?P<month>\d\d)(-(?P<day>\d\d))?)?(T\
-(?P<hour>\d\d):(?P<minute>\d\d)(:(?P<second>\d\d)(\.(?P<microsecond>\d+))?)?)?\
-(?P<timezone>Z|((\+|-)\d\d:\d\d))?"
-dateReg = re.compile(ISO8601Pattern)
-ARK_ID_REGEX = re.compile(r'ark:/67531/\w.*')
-TYPE_LIST = Event.objects.order_by().values_list(
-    'event_type', flat=True
-).distinct()
-OUTCOME_LIST = Event.objects.order_by().values_list(
-    'event_outcome', flat=True
-).distinct()
-AGENT_LIST = Event.objects.order_by().values_list(
-    'linking_agent_identifier_value', flat=True
-).distinct()
+
 XML_HEADER = "<?xml version=\"1.0\"?>\n%s"
 
 # Get a request's body (POST data). Works with all Django versions.

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -114,18 +114,14 @@ def paginate_entries(request, entries, num_per_page=20):
 
 
 def event_search(request):
-    """
-    Return a human readable list of search results
-    """
-
+    """Return a human readable list of search results."""
     form = EventSearchForm(request.GET)
     data = form.cleaned_data if form.is_valid() else {}
 
     events = Event.objects.search(**data)
+    results = paginate_entries(request, events)
 
-    paginated_entries = paginate_entries(request, events, num_per_page=20)
-    context = {'search_form': form, 'entries': paginated_entries}
-
+    context = {'search_form': form, 'entries': results}
     return render(request, 'premis_event_service/search.html', context)
 
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 tox
 pytest==2.7.3
-pytest-django==2.8.0
+pytest-django==2.9.1
 factory_boy==2.5.2
 mock==1.3.0

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,22 +5,16 @@ import factory.fuzzy
 
 from django.utils import timezone
 
-from premis_event_service import models
+from premis_event_service import models, settings
 
 
 UUID_TYPE = 'http://purl.org/net/untl/vocabularies/identifier-qualifiers/#UUID'
 
 URL_TYPE = 'http://purl.org/net/untl/vocabularies/identifier-qualifiers/#URL'
 
-EVENT_TYPES = [
-    'http://purl.org/net/untl/vocabularies/preservationEvents/#replication',
-    'http://purl.org/net/untl/vocabularies/preservationEvents/#fixityCheck'
-]
+EVENT_TYPES = [value for value, _ in settings.EVENT_TYPE_CHOICES]
 
-EVENT_OUTCOMES = [
-    'http://purl.org/net/untl/vocabularies/eventOutcomes/#success',
-    'http://purl.org/net/untl/vocabularies/eventOutcomes/#failure'
-]
+EVENT_OUTCOMES = [value for value, _ in settings.EVENT_OUTCOME_CHOICES]
 
 AGENTS = [
     'http://example.com/agent/codareplicationverification',

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -38,7 +38,7 @@ class LinkObjectFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.LinkObject
 
-    object_identifier = factory.Sequence(lambda n: 'ark:/00001/coda{0}'.format(n))
+    object_identifier = factory.Sequence(lambda n: 'ark:/67531/coda{0}'.format(n))
     object_type = 'http://purl.org/net/untl/vocabularies/identifier-qualifiers/#ARK'
     object_role = None
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -38,7 +38,7 @@ class LinkObjectFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.LinkObject
 
-    object_identifier = factory.Sequence(lambda n: 'ark:/67531/coda{0}'.format(n))
+    object_identifier = factory.Sequence(lambda n: 'ark:/00001/coda{0}'.format(n))
     object_type = 'http://purl.org/net/untl/vocabularies/identifier-qualifiers/#ARK'
     object_role = None
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,7 +1,7 @@
 import os
 
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 SECRET_KEY = 'p&grn73^$c!ae=o)igek_rn2t#(_sb9g1kqwxcpv16-ie__1=1'
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,8 @@
+from django.utils import timezone
 import pytest
 
-from django.utils import timezone
-from . import factories
 from premis_event_service import models
+from . import factories
 
 
 class TestAgent:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -83,7 +83,7 @@ class TestEventManager:
     def test_search_filters_by_start_date(self, manager):
         event = factories.EventFactory.create(event_date_time=timezone.now())
 
-        # Create a batch of events that occur before the intial event.
+        # Create a batch of events that occur before the initial event.
         event_date_time = timezone.now().replace(2015, 1, 1)
         factories.EventFactory.create_batch(30, event_date_time=event_date_time)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -651,27 +651,13 @@ class TestEventSearch:
 
         assert self.response_has_event(response, event)
 
-    def test_filter_by_fully_qualified_linked_object_id(self, client):
+    def test_filter_by_linked_object_id(self, client):
         factories.EventFactory.create_batch(30)
         event = factories.EventFactory.create(linking_objects=True)
         linking_object = event.linking_objects.first()
 
         url = reverse('event-search')
         response = client.get(url, {'linked_object_id': linking_object.object_identifier})
-
-        assert self.response_has_event(response, event)
-
-    def test_filter_by_linked_object_id(self, client):
-        factories.EventFactory.create_batch(30)
-        event = factories.EventFactory.create(linking_objects=True)
-
-        linking_object = event.linking_objects.first()
-        object_id = (linking_object.object_identifier
-                                   .split('/')
-                                   .pop())
-
-        url = reverse('event-search')
-        response = client.get(url, {'linked_object_id': object_id})
 
         assert self.response_has_event(response, event)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -682,7 +682,7 @@ class TestEventSearch:
         event = factories.EventFactory.create(event_outcome=second_outcome)
 
         url = reverse('event-search')
-        response = client.get(url, {'outcome': second_outcome})
+        response = client.get(url, {'event_outcome': second_outcome})
 
         assert self.response_has_event(response, event)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -636,9 +636,8 @@ class TestEventSearch:
         factories.EventFactory.create_batch(30, event_date_time=datetime_obj)
         event = factories.EventFactory.create(event_date_time=timezone.now())
 
-        query_string = '?start_date=01/31/2015'
         url = reverse('event-search')
-        response = client.get(url + query_string)
+        response = client.get(url, {'start_date': '01/31/2015'})
 
         assert self.response_has_event(response, event)
 
@@ -647,9 +646,8 @@ class TestEventSearch:
         factories.EventFactory.create_batch(30, event_date_time=timezone.now())
         event = factories.EventFactory.create(event_date_time=datetime_obj)
 
-        query_string = '?end_date=01/31/2015'
         url = reverse('event-search')
-        response = client.get(url + query_string)
+        response = client.get(url, {'end_date': '01/31/2015'})
 
         assert self.response_has_event(response, event)
 
@@ -658,9 +656,8 @@ class TestEventSearch:
         event = factories.EventFactory.create(linking_objects=True)
         linking_object = event.linking_objects.first()
 
-        query_string = '?linked_object_id={0}'.format(linking_object.object_identifier)
         url = reverse('event-search')
-        response = client.get(url + query_string)
+        response = client.get(url, {'linked_object_id': linking_object.object_identifier})
 
         assert self.response_has_event(response, event)
 
@@ -695,9 +692,8 @@ class TestEventSearch:
         factories.EventFactory.create_batch(10, event_type=first_type)
         event = factories.EventFactory.create(event_type=second_type)
 
-        query_string = '?event_type={0}'.format(second_type)
         url = reverse('event-search')
-        response = client.get(url + query_string)
+        response = client.get(url, {'event_type': second_type})
 
         assert self.response_has_event(response, event)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -631,55 +631,19 @@ class TestEventSearch:
         context = response.context[-1]
         assert len(context['entries']) == self.RESULTS_PER_PAGE
 
-    def test_filter_by_start_date(self, client):
-        datetime_obj = timezone.now().replace(2015, 1, 1)
-        factories.EventFactory.create_batch(30, event_date_time=datetime_obj)
-        event = factories.EventFactory.create(event_date_time=timezone.now())
-
-        url = reverse('event-search')
-        response = client.get(url, {'start_date': '01/31/2015'})
-
-        assert self.response_has_event(response, event)
-
-    def test_filter_by_end_date(self, client):
-        datetime_obj = timezone.now().replace(2015, 1, 1)
-        factories.EventFactory.create_batch(30, event_date_time=timezone.now())
-        event = factories.EventFactory.create(event_date_time=datetime_obj)
-
-        url = reverse('event-search')
-        response = client.get(url, {'end_date': '01/31/2015'})
-
-        assert self.response_has_event(response, event)
-
-    def test_filter_by_linked_object_id(self, client):
-        factories.EventFactory.create_batch(30)
+    def test_filtering_results(self, client):
         event = factories.EventFactory.create(linking_objects=True)
         linking_object = event.linking_objects.first()
 
-        url = reverse('event-search')
-        response = client.get(url, {'linked_object_id': linking_object.object_identifier})
-
-        assert self.response_has_event(response, event)
-
-    def test_filter_by_outcome(self, client, rf):
-        first_outcome, second_outcome = factories.EVENT_OUTCOMES[0:2]
-
-        factories.EventFactory.create_batch(30, event_outcome=first_outcome)
-        event = factories.EventFactory.create(event_outcome=second_outcome)
+        factories.EventFactory.create_batch(30)
 
         url = reverse('event-search')
-        response = client.get(url, {'event_outcome': second_outcome})
-
-        assert self.response_has_event(response, event)
-
-    def test_filter_by_event_type(self, client):
-        first_type, second_type = factories.EVENT_TYPES[0:2]
-
-        factories.EventFactory.create_batch(10, event_type=first_type)
-        event = factories.EventFactory.create(event_type=second_type)
-
-        url = reverse('event-search')
-        response = client.get(url, {'event_type': second_type})
+        response = client.get(
+            url, {
+                'event_outcome': event.event_outcome,
+                'event_type': event.event_type,
+                'linked_object_id': linking_object.object_identifier
+            })
 
         assert self.response_has_event(response, event)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -665,23 +665,24 @@ class TestEventSearch:
 
         assert self.response_has_event(response, event)
 
-    def test_filter_by_outcome(self, client):
-        event_outcome = 'Test outcome'
-        factories.EventFactory.create_batch(30)
-        event = factories.EventFactory.create(event_outcome=event_outcome)
+    def test_filter_by_outcome(self, client, rf):
+        first_outcome, second_outcome = factories.EVENT_OUTCOMES[0:2]
 
-        query_string = '?outcome={0}'.format(event_outcome)
+        factories.EventFactory.create_batch(30, event_outcome=first_outcome)
+        event = factories.EventFactory.create(event_outcome=second_outcome)
+
         url = reverse('event-search')
-        response = client.get(url + query_string)
+        response = client.get(url, {'outcome': second_outcome})
 
         assert self.response_has_event(response, event)
 
     def test_filter_by_event_type(self, client):
-        event_type = 'Test Event Type'
-        factories.EventFactory.create_batch(30)
-        event = factories.EventFactory.create(event_type=event_type)
+        first_type, second_type = factories.EVENT_TYPES[0:2]
 
-        query_string = '?event_type={0}'.format(event_type)
+        factories.EventFactory.create_batch(10, event_type=first_type)
+        event = factories.EventFactory.create(event_type=second_type)
+
+        query_string = '?event_type={0}'.format(second_type)
         url = reverse('event-search')
         response = client.get(url + query_string)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -653,8 +653,7 @@ class TestEventSearch:
 
         assert self.response_has_event(response, event)
 
-    @pytest.mark.xfail(reason='Magic strings prevent block from executing.')
-    def test_filter_by_linked_object_id(self, client):
+    def test_filter_by_fully_qualified_linked_object_id(self, client):
         factories.EventFactory.create_batch(30)
         event = factories.EventFactory.create(linking_objects=True)
         linking_object = event.linking_objects.first()
@@ -662,6 +661,20 @@ class TestEventSearch:
         query_string = '?linked_object_id={0}'.format(linking_object.object_identifier)
         url = reverse('event-search')
         response = client.get(url + query_string)
+
+        assert self.response_has_event(response, event)
+
+    def test_filter_by_linked_object_id(self, client):
+        factories.EventFactory.create_batch(30)
+        event = factories.EventFactory.create(linking_objects=True)
+
+        linking_object = event.linking_objects.first()
+        object_id = (linking_object.object_identifier
+                                   .split('/')
+                                   .pop())
+
+        url = reverse('event-search')
+        response = client.get(url, {'linked_object_id': object_id})
 
         assert self.response_has_event(response, event)
 


### PR DESCRIPTION
This is refactors the `premis_event_service.views.event_search`. Previously, this function was filtering a queryset, delivering a form, parsing the query parameters, and sending a plethora of things to the template (most of which were not used). 

This refactoring is aimed at changing the views responsibility to merely handling the request, instead of doing *all* the work.

### Summary

* A new `EventManager` was created that has a single `search` method that allows us to filter based on the same criteria as the previous version of `event_search`. This will become beneficial when we refactor `event_search_json`, which duplicates much of the filtering of `event_search`.
* The `EventSearchForm` is now responsible for handling the search parameters. This means converting datetime strings to datetime objects, stripping whitespace, etc.
* The number of queries has been reduced from ~22 per request down to 3.
* Cleaning up formatting and style of related code along the way.