### PR TITLE
Optimize queries.

### DIFF
--- a/premis_event_service/templates/premis_event_service/recent_event_list.html
+++ b/premis_event_service/templates/premis_event_service/recent_event_list.html
@@ -8,7 +8,7 @@
     </div>
 
 <!-- If we have entries, iterate and display them -->
-{% if entries %}
+{% if entries.exists %}
     <table id="results" class="table table-striped table-hover">
         <thead><tr>
             <th>
@@ -40,7 +40,7 @@
                     <i class="icon-asterisk"></i> {{ entry.event_type }}
                 </td>
                 <td>
-                    {% for lo in entry.linking_objects.values %}<i class="icon-link"></i> <a href='http://{{ request.META.HTTP_HOST }}/bag/{{ lo.object_identifier }}'>{{ lo.object_identifier }}</a>{% endfor %}
+                    {% for lo in entry.linking_objects.all %}<i class="icon-link"></i> <a href='http://{{ request.META.HTTP_HOST }}/bag/{{ lo.object_identifier }}'>{{ lo.object_identifier }}</a>{% endfor %}
                 </td>
                 <td>
                     <span title="{{ entry.entry_outcome }}" class="label label-{{ entry.is_good|yesno:"success,important" }}">{{ entry.event_outcome|slice:"53:" }}</span>

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -281,7 +281,11 @@ def recent_event_list(request):
     Return a tabled list of 10 most recent events
     """
 
-    events = Event.objects.all().order_by('-event_date_time')[:10]
+    events = (Event.objects
+                   .all()
+                   .prefetch_related('linking_objects')
+                   .order_by('-event_date_time')[:10])
+
     # render to the template
     return render_to_response(
         'premis_event_service/recent_event_list.html',


### PR DESCRIPTION
Reduces the number of queries issued by `recent_event_list` from ~12 to
~4.

Completes #20  (`event_search` was optimized as part of #56)