### PR TITLE
Event Search Fixes/Optimizations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
         environment:
             - DJANGO_SETTINGS_MODULE=tests.settings
             - PES_BACKEND=mysql
+            - PES_DEBUG_TOOLBAR=on
         command: ./appstart.sh
         ports:
             - "8000:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,12 @@ services:
             - db
         environment:
             - DJANGO_SETTINGS_MODULE=tests.settings
+            # Comment for sqlite
             - PES_BACKEND=mysql
+            # Comment to disable debug toolbar.
             - PES_DEBUG_TOOLBAR=on
+            # Uncomment for query logging.
+            # - PES_DBDEBUG=on
         command: ./appstart.sh
         ports:
             - "8000:80"

--- a/premis_event_service/migrations/0002_add_event_ordinal.py
+++ b/premis_event_service/migrations/0002_add_event_ordinal.py
@@ -62,24 +62,55 @@ def forward_sqlite(apps, schema_editor):
 def forward_mysql(apps, schema_editor):
     cur = schema_editor.connection.cursor()
     cur.execute(
-        """lock tables 
+        """
+        lock tables 
         premis_event_service_event write,
         premis_event_service_event_linking_objects write,
-        premis_event_service_linkobject write"""
+        premis_event_service_linkobject write
+        """
     )
     cur.execute(
-        """alter table premis_event_service_event drop primary key;"""
+        """
+        alter table premis_event_service_event drop primary key
+        """
     )
     cur.execute(
-        """alter table premis_event_service_event add unique(event_identifier);"""
+        """
+        alter table premis_event_service_event add unique(event_identifier)
+        """
     )
     cur.execute(
-        """alter table premis_event_service_event add column 
-        ordinal int not null primary key auto_increment first;
-    """
+        """
+        alter table premis_event_service_event add column 
+        ordinal int not null default 0 first
+        """
     )
     cur.execute(
-        """unlock tables"""
+        """
+        set @ord = 0
+        """
+    )
+    cur.execute(
+        """
+        update premis_event_service_event set ordinal = (@ord:=@ord+1)
+        order by event_added asc, event_identifier desc
+        """
+    )
+    cur.execute(
+        """
+        alter table premis_event_service_event add index
+        premis_event_service_event_ordinal_idx (ordinal)
+        """
+    )
+    cur.execute(
+        """
+        alter table premis_event_service_event change ordinal ordinal int not null
+        auto_increment primary key
+        """
+    )
+    cur.execute(
+        """unlock tables
+        """
     )
 
 

--- a/premis_event_service/migrations/0002_add_event_ordinal.py
+++ b/premis_event_service/migrations/0002_add_event_ordinal.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def forward_sqlite(apps, schema_editor):
+    cur = schema_editor.connection.cursor()
+    cur.execute(
+        """create table pesetmp (
+            "ordinal" integer primary key,
+            "event_identifier" varchar(64) NOT NULL UNIQUE,
+            "event_identifier_type" varchar(255) NOT NULL, 
+            "event_type" varchar(255) NOT NULL, 
+            "event_date_time" datetime NOT NULL, 
+            "event_added" datetime NOT NULL, "event_detail" text NOT NULL, 
+            "event_outcome" varchar(255) NOT NULL, 
+            "event_outcome_detail" text NOT NULL, 
+            "linking_agent_identifier_type" varchar(255) NOT NULL, 
+            "linking_agent_identifier_value" varchar(255) NOT NULL, 
+            "linking_agent_role" varchar(255) NOT NULL
+        );"""
+    )
+    cur.execute(
+        """insert into pesetmp
+            (ordinal, event_identifier, event_identifier_type, event_type, event_date_time,
+            event_added, event_outcome, event_outcome_detail, linking_agent_identifier_type,
+            linking_agent_identifier_value, linking_agent_role)
+            select null, event_identifier, event_identifier_type, event_type, event_date_time,
+            event_added, event_outcome, event_outcome_detail, linking_agent_identifier_type,
+            linking_agent_identifier_value, linking_agent_role 
+            from premis_event_service_event;"""
+    )
+    cur.execute(
+        """drop table premis_event_service_event;"""
+    )
+    cur.execute(
+        """create index "premis_event_service_event_1cd03614" 
+        on "pesetmp" ("event_type");"""
+    )
+    cur.execute(
+        """create index "premis_event_service_event_afe44630" 
+        on "pesetmp" ("event_date_time");"""
+    )
+    cur.execute(
+        """create index "premis_event_service_event_eefc032c" 
+        on "pesetmp" ("event_added");"""
+    )
+    cur.execute(
+        """create index "premis_event_service_event_d8893bd6" 
+        on "pesetmp" ("event_outcome");"""
+    )
+    cur.execute(
+        """create index "premis_event_service_event_854a1fa6" 
+        on "pesetmp" ("linking_agent_identifier_value");"""
+    )
+    cur.execute(
+        """alter table pesetmp rename to premis_event_service_event;"""
+    )
+
+
+def forward_mysql(apps, schema_editor):
+    cur = schema_editor.connection.cursor()
+    cur.execute(
+        """lock tables 
+        premis_event_service_event write,
+        premis_event_service_event_linking_objects write,
+        premis_event_service_linkobject write"""
+    )
+    cur.execute(
+        """alter table premis_event_service_event drop primary key;"""
+    )
+    cur.execute(
+        """alter table premis_event_service_event add unique(event_identifier);"""
+    )
+    cur.execute(
+        """alter table premis_event_service_event add column 
+        ordinal int not null primary key auto_increment first;
+    """
+    )
+    cur.execute(
+        """unlock tables"""
+    )
+
+
+def forward(apps, schema_editor):
+    backend = schema_editor.connection.vendor
+    if backend == 'sqlite':
+        forward_sqlite(apps, schema_editor)
+    else:
+        forward_mysql(apps, schema_editor)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('premis_event_service', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(forward),
+        migrations.RunSQL('select 1;', state_operations=[
+
+            migrations.AddField(
+                model_name='event',
+                name='ordinal',
+                field=models.AutoField(
+                    primary_key=True
+                ),
+            ),
+            migrations.AlterField(
+                model_name='event',
+                name='event_identifier',
+                field=models.CharField(
+                    help_text=(
+                        b'Unique identifier for an event. '
+                        'example: urn:uuid:12345678-1234-5678-1234-567812345678'
+                    ),
+                    unique=True,
+                    max_length=64,
+                    editable=False,
+                    db_index=True
+                ),
+            ),
+        ])
+    ]

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -214,6 +214,8 @@ class EventLinkObject(models.Model):
     class Meta:
         # Not sure how to get the app label here *and* set the table name
         db_table = 'premis_event_service_event_linking_objects'
+        # Without this, the Django ORM won't permit add/create/save/remove
+        # without a custome manager for the linking field.
         auto_created = True
     
     event_id = models.ForeignKey(Event, to_field='event_identifier', db_column='event_id')

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -128,8 +128,6 @@ class EventManager(models.Manager):
             # it's possible.
             else:
                 max_ordinal = 0
-        else:
-            pass
         qs = self.get_queryset().order_by('-ordinal')
         qs = qs.filter(ordinal__lt=max_ordinal)
         return qs

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -214,6 +214,7 @@ class EventLinkObject(models.Model):
     class Meta:
         # Not sure how to get the app label here *and* set the table name
         db_table = 'premis_event_service_event_linking_objects'
+        auto_created = True
     
     event_id = models.ForeignKey(Event, to_field='event_identifier', db_column='event_id')
     linkobject_id = models.ForeignKey(LinkObject, to_field='object_identifier', db_column='linkobject_id')

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -115,13 +115,19 @@ class Event(models.Model):
 
     objects = EventManager()
 
+    ordinal = models.AutoField(
+        primary_key=True,
+    )
+
     help_text = "Unique identifier for an event. example: " + \
         "urn:uuid:12345678-1234-5678-1234-567812345678"
     event_identifier = models.CharField(
-        primary_key=True,
         max_length=64,
         editable=False,
-        help_text=help_text
+        help_text=help_text,
+        unique=True,
+        null=False,
+        db_index=True
     )
     event_identifier_type = models.CharField(
         max_length=255,
@@ -175,7 +181,11 @@ class Event(models.Model):
         max_length=255,
         help_text="The role of the agent in relation to this event."
     )
-    linking_objects = models.ManyToManyField(LinkObject)
+    linking_objects = models.ManyToManyField(
+        LinkObject,
+        through='EventLinkObject',
+        through_fields=('event_id', 'linkobject_id')
+    )
 
     def __unicode__(self):
         return self.event_identifier
@@ -198,3 +208,14 @@ class Event(models.Model):
 
     is_good.short_description = "Pass?"
     is_good.boolean = True
+
+class EventLinkObject(models.Model):
+
+    class Meta:
+        # Not sure how to get the app label here *and* set the table name
+        db_table = 'premis_event_service_event_linking_objects'
+    
+    event_id = models.ForeignKey(Event, to_field='event_identifier', db_column='event_id')
+    linkobject_id = models.ForeignKey(LinkObject, to_field='object_identifier', db_column='linkobject_id')
+
+

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -194,6 +194,12 @@ class Event(models.Model):
         ordering = ["event_added"]
 
     def link_objects_string(self):
+        # Django ORM requires a PK value before
+        # custom relations can be created. This
+        # save call ensures we have one before
+        # accessing linking_objects.
+        if not self.ordinal:
+            self.save()
         values = self.linking_objects.values()
         idList = []
         for value in values:
@@ -209,6 +215,7 @@ class Event(models.Model):
     is_good.short_description = "Pass?"
     is_good.boolean = True
 
+
 class EventLinkObject(models.Model):
 
     class Meta:
@@ -217,8 +224,10 @@ class EventLinkObject(models.Model):
         # Without this, the Django ORM won't permit add/create/save/remove
         # without a custome manager for the linking field.
         auto_created = True
-    
-    event_id = models.ForeignKey(Event, to_field='event_identifier', db_column='event_id')
-    linkobject_id = models.ForeignKey(LinkObject, to_field='object_identifier', db_column='linkobject_id')
 
-
+    event_id = models.ForeignKey(
+        Event, to_field='event_identifier', db_column='event_id'
+    )
+    linkobject_id = models.ForeignKey(
+        LinkObject, to_field='object_identifier', db_column='linkobject_id'
+    )

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -129,7 +129,7 @@ class EventManager(models.Manager):
             else:
                 max_ordinal = 0
         qs = self.get_queryset().order_by('-ordinal')
-        qs = qs.filter(ordinal__lt=max_ordinal)
+        qs = qs.filter(ordinal__lte=max_ordinal)
         return qs
 
 

--- a/premis_event_service/models.py
+++ b/premis_event_service/models.py
@@ -249,7 +249,7 @@ class EventLinkObject(models.Model):
         # Not sure how to get the app label here *and* set the table name
         db_table = 'premis_event_service_event_linking_objects'
         # Without this, the Django ORM won't permit add/create/save/remove
-        # without a custome manager for the linking field.
+        # without a custom manager for the linking field.
         auto_created = True
 
     event_id = models.ForeignKey(

--- a/premis_event_service/settings.py
+++ b/premis_event_service/settings.py
@@ -47,10 +47,10 @@ EVENT_TYPE_CHOICES = getattr(
     settings, 'EVENT_TYPE_CHOICES',
     (
         ('', 'None'),
-        ('http://id.loc.gov/vocabulary/preservation/eventType/fix', 'Fixity Check'),
-        ('http://id.loc.gov/vocabulary/preservation/eventType/rep', 'Replication'),
-        ('http://id.loc.gov/vocabulary/preservation/eventType/ing', 'Ingestion'),
-        ('http://id.loc.gov/vocabulary/preservation/eventType/mig', 'Migration'),
+        ('http://purl.org/net/untl/vocabularies/preservationEvents/#fixityCheck', 'Fixity Check'),
+        ('http://purl.org/net/untl/vocabularies/preservationEvents/#replication', 'Replication'),
+        ('http://purl.org/net/untl/vocabularies/preservationEvents/#ingestion', 'Ingestion'),
+        ('http://purl.org/net/untl/vocabularies/preservationEvents/#migration', 'Migration'),
     )
 )
 

--- a/premis_event_service/templates/premis_event_service/search.html
+++ b/premis_event_service/templates/premis_event_service/search.html
@@ -81,7 +81,7 @@
             {% endif %}
 
             {% if page > 1 %}
-            <li><a href="?page={{ previous_page }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}&amp;min_ordinal={{ min_ordinal }}">prev</a></li>
+            <li><a href="?page={{ previous_page }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}&amp;min_ordinal={{ prev_page_ord }}">prev</a></li>
             {% else %}
                 <li class="disabled"><span>prev</span></li>
             {% endif %}
@@ -100,7 +100,7 @@
             {% endfor %}
 
             {% if page < max_page %}
-            <li><a href="?page={{ next_page }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}&amp;min_ordinal={{ min_ordinal }}">next</a></li>
+            <li><a href="?page={{ next_page }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}&amp;min_ordinal={{ next_page_ord }}">next</a></li>
             {% else %}
                 <li class="disabled"><span>next</span></li>
             {% endif %}

--- a/premis_event_service/templates/premis_event_service/search.html
+++ b/premis_event_service/templates/premis_event_service/search.html
@@ -30,7 +30,7 @@
     </div>
 </form>
 <!-- If we have entries, iterate and display them -->
-{% if entries %}
+{% if events %}
     <table id="data" class="table table-striped table-hover">
         <thead><tr>
             <th>
@@ -50,63 +50,63 @@
             </th>
         </tr></thead>
         <!-- iterate through search results and display if not suppressed / deleted -->
-        {% for entry in entries.object_list %}
+        {% for event in events %}
             <tr>
                 <td>
-                    <i class="icon-tag"></i> <a href='http://{{ request.META.HTTP_HOST }}/event/{{ entry.event_identifier }}'>{{ entry.event_identifier }}</a>
+                    <i class="icon-tag"></i> <a href='http://{{ request.META.HTTP_HOST }}/event/{{ event.event_identifier }}'>{{ event.event_identifier }}</a>
                 </td>
                 <td>
-                    <i class="icon-calendar"></i> {{ entry.event_date_time }}
+                    <i class="icon-calendar"></i> {{ event.event_date_time }}
                 </td>
                 <td>
-                    <i class="icon-asterisk"></i> {{ entry.event_type }}
+                    <i class="icon-asterisk"></i> {{ event.event_type }}
                 </td>
                 <td>
-                    {% for lo in entry.linking_objects.all %}<i class="icon-link"></i> <a href='http://{{ request.META.HTTP_HOST }}/bag/{{ lo.object_identifier }}'>{{ lo.object_identifier }}</a>{% endfor %}
+                    {% for lo in event.linking_objects.all %}<i class="icon-link"></i> <a href='http://{{ request.META.HTTP_HOST }}/bag/{{ lo.object_identifier }}'>{{ lo.object_identifier }}</a>{% endfor %}
                 </td>
                 <td>
-                    <span title="{{ entry.entry_outcome }}" class="disabled btn btn-block btn-mini btn-{{ entry.is_good|yesno:"success,danger" }}">{{ entry.event_outcome|slice:"53:" }}</span>
+                    <span title="{{ event.event_outcome }}" class="disabled btn btn-block btn-mini btn-{{ event.is_good|yesno:"success,danger" }}">{{ event.event_outcome|slice:"53:" }}</span>
                 </td>
             </tr>
         {% endfor %}
     </table>
 {% endif %}
-{% if entries.paginator.num_pages > 1 %}
+{% if page_range %}
     <div class="pagination pagination-centered">
         <ul>
-            {% if entries.number != 1 %}
+            {% if page != 1 %}
                 <li><a href="?page=1&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">first</a></li>
             {% else %}
                 <li class="disabled"><span>first</span></li>
             {% endif %}
 
-            {% if entries.has_previous %}
-                <li><a href="?page={{ entries.previous_page_number }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">prev</a></li>
+            {% if page > 1 %}
+            <li><a href="?page={{ previous_page }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}&amp;min_ordinal={{ min_ordinal }}">prev</a></li>
             {% else %}
                 <li class="disabled"><span>prev</span></li>
             {% endif %}
 
-            {% for page in entries.paginator.page_range %}
-                {% if entries.number == page %}
-                    <li class="disabled"><span>{{ page }}</span></li>
+            {% for thispage, page_min_ord in page_offsets %}
+                {% if page == thispage %}
+                    <li class="disabled"><span>{{ thispage }}</span></li>
 
-                {% else %} {% if page > entries.number|add:"-6" and page < entries.number|add:"6"  %}
+                {% else %}
                     <li>
-                        <a href="?page={{ page }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">
-                            {{ page }}
+                        <a href="?page={{ thispage }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}&amp;min_ordinal={{ page_min_ord }}">
+                            {{ thispage }}
                         </a>
                     </li>
-                {% endif %}{% endif %}
+                {% endif %}
             {% endfor %}
 
-            {% if entries.has_next %}
-                <li><a href="?page={{ entries.next_page_number }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">next</a></li>
+            {% if page < max_page %}
+            <li><a href="?page={{ next_page }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}&amp;min_ordinal={{ min_ordinal }}">next</a></li>
             {% else %}
                 <li class="disabled"><span>next</span></li>
             {% endif %}
 
-            {% if entries.number != entries.paginator.num_pages %}
-                <li><a href="?page={{ entries.paginator.num_pages }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}">last</a></li>
+            {% if page != max_page %}
+            <li><a href="?page={{ max_page }}&amp;event_outcome={{ request.GET.event_outcome|urlencode }}&amp;event_type={{ request.GET.event_type|urlencode }}&amp;start_date={{ request.GET.start_date|urlencode }}&amp;end_date={{ request.GET.end_date|urlencode }}&amp;linked_object_id={{ request.GET.linking_object_id|urlencode }}&amp;min_ordinal={{ last_page_ordinal }}">last</a></li>
             {% else %}
                 <li class="disabled"><span>last</span></li>
             {% endif %}

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -97,10 +97,12 @@ def humanEvent(request, identifier=None):
 
 
 def last_page_ordinal(query_set, per_page=20):
-    qa = query_set.order_by('ordinal')[0:20]
-    for event in qa:
-        pass
-    return event.ordinal
+    # To evaluate the queryset, you have to iterate
+    # or use a step in the slice. And if you don't
+    # evaluate the queryset, you can't get the
+    # ordinal of the last item in the result set.
+    evt = query_set.order_by('ordinal')[0:20:1][-1]
+    return evt.ordinal
 
 
 def get_page_offsets(query_set, page, page_range, page_lims, per_page=20):

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -109,7 +109,6 @@ def get_page_offsets(query_set, page, page_range, page_lims, per_page=20):
     page_min_ord, page_max_ord = page_lims
     p0 = page_range[0]
     pN = page_range[-1]
-    print 'GETPGOFF', page_lims, page_range
     query_set = query_set.only('ordinal')
     limit = (page-p0) * per_page
     ordinals = []

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -118,15 +118,15 @@ def get_page_offsets(query_set, page, page_range, page_lims, per_page=20):
     p0 = page_range[0]
     pN = page_range[-1]
     query_set = query_set.only('ordinal')
-    limit = (page-p0) * per_page
+    limit = (page-p0+1) * per_page
     ordinals = []
     if limit:
         offset_qs = query_set.filter(ordinal__gte=page_max_ord).order_by('ordinal')[0:limit]
-        ordinals = [evt.ordinal for ei, evt in enumerate(offset_qs) if not ei % per_page]
+        ordinals = [evt.ordinal for ei, evt in enumerate(offset_qs) if ei and not ei % per_page]
         ordinals = ordinals[::-1]
     offsets_lo = [p for p in page_range if p < page]
     offsets_lo = zip(offsets_lo, ordinals)
-    limit = (pN-page) * per_page if pN > page else 0
+    limit = (pN-page+1) * per_page if pN > page else 1
     ordinals = []
     if limit:
         offset_qs = query_set.filter(ordinal__lte=page_max_ord).order_by('-ordinal')[0:limit]
@@ -175,13 +175,13 @@ def paginate_events(valid, request, per_page=20):
         raise EmptyPage()
     page_range = range(
         max(1, page-6),
-        min(max_page, page+7)
+        min(max_page+1, page+7)
     )
     page_offsets = get_page_offsets(
         page_offset_qs, page, page_range, (page_min_ord, page_max_ord),
         per_page=per_page
     )
-    prev_page_ord = page_max_ord
+    prev_page_ord = page_max_ord+per_page
     next_page_ord = page_min_ord
     for p, poff in page_offsets:
         if p == (page-1):

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -115,7 +115,7 @@ def paginate_events(valid, request, per_page=20):
         events = (Event.objects.search(**valid)
                   .prefetch_related('linking_objects'))
         total_events = events.count()
-        offset = (page-1)*per_page
+        offset = (page-1) * per_page
         last_page_ord = last_page_ordinal(events)
         # The min_ordinal is actually the "bottom" (end) of the current
         # page and the top (start) of the next. This is because the

--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -96,17 +96,24 @@ def humanEvent(request, identifier=None):
     )
 
 
+def last_page_ordinal(query_set, per_page=20):
+    qa = query_set.order_by('ordinal')[0:20]
+    return qa.last().ordinal
+
+
 def paginate_events(valid, request, per_page=20):
     total_events = None
     events = None
     page = int(request.GET.get('page', 1))
     offset = None
     unfiltered = True
+    last_page_ord = per_page+1
     if any([v for k, v in valid.items() if k != 'min_ordinal']):
         events = (Event.objects.search(**valid)
                   .prefetch_related('linking_objects'))
         total_events = events.count()
         offset = (page-1)*per_page
+        last_page_ord = last_page_ordinal(events)
         if 'min_ordinal' in valid and valid['min_ordinal']:
             events = events.filter(ordinal__lte=valid['min_ordinal'])[:20]
         else:
@@ -138,7 +145,7 @@ def paginate_events(valid, request, per_page=20):
     context = {
         'events': events, 'page_range': page_range, 'page_offsets': page_offsets,
         'page_max_ordinal': page_max_ord, 'page_min_ordinal': page_min_ord,
-        'last_page_ordinal': per_page+1, 'page': page, 'max_page': max_page,
+        'last_page_ordinal': last_page_ord, 'page': page, 'max_page': max_page,
         'per_page': per_page, 'next_page': page+1, 'previous_page': page-1
     }
     return context

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 lxml==3.0.0
 codalib==1.0.3
 MySQL-python
+sqlparse

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,3 @@
 lxml==3.0.0
-#codalib==1.0.2
-git+https://github.com/unt-libraries/codalib
+codalib==1.0.3
 MySQL-python

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 lxml==3.0.0
-codalib==1.0.2
+#codalib==1.0.2
+git+https://github.com/unt-libraries/codalib
 MySQL-python

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,1 +1,2 @@
 Django~=1.8.0
+django-debug-toolbar

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -71,6 +71,29 @@ else:
         }
     }
 
+if os.getenv('PES_DBDEBUG') == 'on':
+    LOGGING = {
+        'version': 1,
+        'filters': {
+            'require_debug_true': {
+                '()': 'django.utils.log.RequireDebugTrue',
+            }
+        },
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                'filters': ['require_debug_true'],
+                'class': 'logging.StreamHandler',
+            }
+        },
+        'loggers': {
+            'django.db.backends': {
+                'level': 'DEBUG',
+                'handlers': ['console'],
+            }
+        }
+    }
+
 ROOT_URLCONF = 'tests.urls'
 
 LANGUAGE_CODE = 'en-us'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -31,7 +31,6 @@ MIDDLEWARE_CLASSES = (
 if os.getenv('PES_DEBUG_TOOLBAR'):
     INSTALLED_APPS += ('debug_toolbar',)
     MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
-    INTERNAL_IPS = ['127.0.0.1']
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': lambda request: True
     }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -27,6 +27,15 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
+# For debug toolbar
+if os.getenv('PES_DEBUG_TOOLBAR'):
+    INSTALLED_APPS += ('debug_toolbar',)
+    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+    INTERNAL_IPS = ['127.0.0.1']
+    DEBUG_TOOLBAR_CONFIG = {
+        'SHOW_TOOLBAR_CALLBACK': lambda request: True
+    }
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,7 @@
+import os
+
 from django.conf.urls import include, url
+import settings
 
 from django.contrib import admin
 admin.autodiscover()
@@ -7,3 +10,9 @@ urlpatterns = [
     url(r'', include('premis_event_service.urls')),
     url(r'^admin/', include(admin.site.urls)),
 ]
+
+if settings.DEBUG and os.getenv('PES_DEBUG_TOOLBAR'):
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]


### PR DESCRIPTION
This remains far from optimal, but it should be functional.

Searching by type works now, and the included migration adds an ordinal to the `event` table to make paging faster.

It should be noted that this migration will lock three critical tables, and on a large dataset can take some time to drop the primary key, add a new column, populate that sequence, add a new primary key, then unlock the tables.