### PR TITLE
Update Documents

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,15 @@ Run the tests using tox_
 
 Note that the tests will be run in multiple environments, most importantly in distinct environments for Django major versions 1.7-1.10. Tests will also be run against the Django master branch, which is a development branch and prone to failure. These failures are ignored by the PREMIS Event Service testing configuration, and you can likely ignore them as well, particularly if you are using one of the other Django major versions against which the tests should pass.
 
+
+Apply the migrations
+""""""""""""""""""""
+
+.. code-block :: sh
+
+    (premis-event-service) $ python manage.py migrate
+
+
 Start the development server
 """"""""""""""""""""""""""""
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ structured, centralized, and searchable manner.
 Purpose
 -------
 
-The purpose of this microservice is to provide a straightforward way to send 
+The purpose of this application is to provide a straightforward way to send 
 PREMIS-formatted events to a central location to be stored and retrieved. In 
 this fashion, it can serve as an event logger for any number of services that 
 happen to wish to use it. PREMIS is chosen as the underlying format for events 
@@ -20,7 +20,7 @@ Dependencies
 ------------
 
 * Python 2.6+ (not Python 3)
-* Django (tested on 1.6.1; at least 1.3 or higher required)
+* Django (tested on 1.7-1.10; 1.3 or higher required)
 * lxml (requires libxml2-dev to be installed on your system)
 
 
@@ -60,34 +60,110 @@ by a number of developers over the years including
 * Stephen Eisenhauer   
 * Mark Phillips
 * Damon Kelley
+* Reed Underwood
 
 If you have questions about the project feel free to contact Mark Phillips at mark.phillips@unt.edu
 
 Developing
 ----------
+There are two (supported) ways to develop the PREMIS event service Django app. One is natively using an SQLite backend. The other is using a MySQL backend for storage inside a Docker container.
 
-To take advantage of the dev environment that is already configured, you need to have Docker and Docker Compose installed.
+Developing Natively Using SQLite_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _SQLite: https://sqlite.org/
+
+Clone the repository
+""""""""""""""""""""
+
+.. code-block :: sh
+
+  $ git clone https://github.com/unt-libraries/django-premis-event-service.git # check the repo for the latest official release if you don't want the development version at HEAD on the master branch
+  $ cd django-premis-event-service
+
+Create a virtualenv_ environment
+""""""""""""""""""""""""""""""""
+
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+
+.. code-block :: sh
+
+    $ mkvirtualenv premis-event-service # to create and enter the virtualenv
+    (premis-event-service) $ deactivate # to exit the virtualenv
+    $ workon premis-event-service # to reactivate the virtualenv
+
+
+Install the requirements using pip_
+"""""""""""""""""""""""""""""""""""
+
+.. _pip: https://pip.pypa.io/en/stable/
+
+.. code-block :: sh
+
+    (premis-event-service) $ pip install -r requirements.txt # install dependencies from text file
+
+
+Run the tests using tox_
+""""""""""""""""""""""""
+
+.. _tox: https://tox.readthedocs.io/en/latest/
+
+.. code-block :: sh
+
+    (premis-event-service) $ tox
+
+
+Note that the tests will be run in multiple environments, most importantly in distinct environments for Django major versions 1.7-1.10. Tests will also be run against the Django master branch, which is a development branch and prone to failure. These failures are ignored by the PREMIS Event Service testing configuration, and you can likely ignore them as well, particularly if you are using one of the other Django major versions against which the tests should pass.
+
+Start the development server
+""""""""""""""""""""""""""""
+
+.. code-block :: sh
+
+    (premis-event-service) $ python manage.py runserver 9999
+
+
+This will start the development server listening locally on port 9999. You may want to change the port number, passed as the first argument to the ``runserver`` command.
+
+
+View the web UI in a browser
+""""""""""""""""""""""""""""
+
+Navigate to ``http://localhost:9999`` (or whatever port you chose) to see the UI of the app.
+
+
+Developing Using Docker and MySQL as a Backend
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Install Docker_
+"""""""""""""""
 
 .. _Docker: https://docs.docker.com
 
+On Debian-derived Linux distros, you can use ``apt-get`` to install. If you're on a different OS, check the Docker site for instructions.
+
+
 Install Docker Compose
+""""""""""""""""""""""
 
 .. code-block :: sh
 
   $ pip install docker-compose
 
+Alternatively, you may want to install ``docker-compose`` using your system's package manager.
 
-Clone the repository.
+
+Clone the repository
+""""""""""""""""""""
 
 .. code-block :: sh
 
-  $ git clone https://github.com/unt-libraries/django-premis-event-service.git
+  $ git clone https://github.com/unt-libraries/django-premis-event-service.git # check the repo for the latest official release if you don't want the development version at HEAD on the master branch
   $ cd django-premis-event-service
 
 
-Start the app and run the migrations.
+Starting the app
+""""""""""""""""
 
 .. code-block :: sh
 
@@ -111,36 +187,26 @@ However, if the requirements files change, it is important that you rebuild the 
   $ docker-compose rm app
 
   # rebuild the app container
-  $ docker-compose build app
+  $ docker-compose build app # under some circumstances, you may need to use the --no-cache switch
 
   # start the app
-  $ docker-compose up -d
+  $ docker-compose up -d db app
+
+
+Viewing the logs
+""""""""""""""""
+
+.. code-block :: sh
+
+    $ docker-compose logs -f
+
 
 Running the Tests
------------------
+"""""""""""""""""
+
 To run the tests via Tox, use this command.
 
 .. code-block :: sh
 
-  $ docker-compose run --rm app tox
+  $ docker-compose run --rm app test 
 
-
-To run the tests only with the development environment.
-
-.. code-block :: sh
-
-  $ docker-compose run --rm app py.test
-
-
-Running Locally, Outside of Docker
-----------------------------------
-
-The event service can also run outside of the Docker container environment using SQLite as a backend. Simply run the app using manage.py as is the convention with Django apps:
-
-.. code-block :: sh
-
-  # start the app
-  $ python manage.py runserver 127.0.0.1:8000
-
-  # or run the tests using tox
-  $ tox

--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,7 @@ This will start the development server listening locally on port 9999. You may w
 View the web UI in a browser
 """"""""""""""""""""""""""""
 
-Navigate to ``http://localhost:9999`` (or whatever port you chose) to see the UI of the app.
+Navigate to ``http://localhost:9999/event/`` (or whatever port you chose) to see the UI of the app.
 
 
 Developing Using Docker and MySQL as a Backend
@@ -183,6 +183,12 @@ Starting the app
   $ docker-compose run manage createsuperuser
 
 
+View the web UI in a browser
+""""""""""""""""""""""""""""
+
+Navigate to ``http://localhost:8000/event/`` to see the UI of the app. The port can be changed by editing the ``docker-compose.yml`` file.
+
+
 The code is in a volume that is shared between your workstation and the app container, which means any edits you make on your workstation will also be reflected in the Docker container. No need to rebuild the container to pick up changes in the code.
 
 However, if the requirements files change, it is important that you rebuild the app container for those packages to be installed. This is something that could happen when switching between feature branches, or when pulling updates from the remote.
@@ -196,7 +202,7 @@ However, if the requirements files change, it is important that you rebuild the 
   $ docker-compose rm app
 
   # rebuild the app container
-  $ docker-compose build app # under some circumstances, you may need to use the --no-cache switch
+  $ docker-compose build app # under some circumstances, you may need to use the --no-cache switch, e.g. upstream changes to packages the app requires
 
   # start the app
   $ docker-compose up -d db app

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ due to its widespread use in the digital libraries world.
 Dependencies
 ------------
 
-* Python 2.6+ (not Python 3)
+* Python 2.7+ (not Python 3)
 * Django (tested on 1.7-1.10; 1.3 or higher required)
 * lxml (requires libxml2-dev to be installed on your system)
 

--- a/docs/source/administration.rst
+++ b/docs/source/administration.rst
@@ -12,14 +12,12 @@ prepare your Event Service for use.
 Manage User Accounts
 ====================
 
-At this point, you might only have one user account in your system (which is 
-the superuser account created when you ran ``python manage.py syncdb`` during 
-installation). 
+To create an admin account, run ``python manage.py createsuperuser`` and follow the prompts.
 
 To manage or create other user accounts, do the following:
 
 1. Visit the Django admin interface (``http://[host]/admin/``) in a web browser.
-2. Log in using your superuser account (if you haven't already).
+2. Log in using your superuser account.
 3. Click **Users**. This takes you to the list of Users.
 4. Click the **Add user** button near the top-right corner of the page.
 5. Fill and submit the form.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,12 +30,16 @@ The PREMIS Event Service makes every effort to conform to the `PREMIS v.2
 specification`_. Versions 2.* of the spec are *not* backwards compatible with
 versions before the 2.0 milestone.
 
+.. _premis v.2 specification: https://www.loc.gov/standards/premis/v2/premis-v2-3.xsd
+
 A Note on Dates
 ---------------
 
-Unless otherwise noted, all datetimes mentioned below *must* be formatted
+Unless otherwise noted, all datetimes mentioned below *must* be formatted_
 as ``xsDateTime`` compliant strings. The output of the ``datetime.isoformat``
 method in Python is compatible.
+
+.. _formatted: https://www.w3.org/TR/xmlschema-2/#dateTime
 
 API URL Structure
 =================
@@ -61,18 +65,14 @@ Accepts parameters:
 
 * start - This is the index of the first record that you want...it starts indexing at 1.
 * count - This is the number of records that you want returned.
-* start_date - This is a date (or partial date ) in ISO8601 format that indicates the earliest
-record that you want.
+* start_date - This is a date (or partial date ) in ISO8601 format that indicates the earliest record that you want.
 * end_date - This is a date that indicates the latest record that you want.
-* type - This is a string identifying a type identifier (or partial identifier) that you want to
-filter events by
+* type - This is a string identifying a type identifier (or partial identifier) that you want to filter events by
 * outcome - This is a string identifying an outcome identifier (partial matching is supported)
-* link_object_id - This is an identifier that specifies that we want events pertaining to a
-particular object
-* orderdir - This defaults to 'ascending'. Specifying 'descending' will return the records in
-reverse order.
-* orderby - This parameter specifies what field to order the records by. The valid fields are
-currently: event_date_time (default), event_identifier, event_type, event_outcome
+* link_object_id - This is an identifier that specifies that we want events pertaining to a particular object
+* orderdir - This defaults to 'ascending'. Specifying 'descending' will return the records in reverse order.
+* orderby - This parameter specifies what field to order the records by. The valid fields are currently: event_date_time (default), event_identifier, event_type, event_outcome
+
 
 For the human-viewable feeds, the parameters are the same, except, instead of using a
 'start' parameter, it uses a 'page' parameter, because of the way it paginates the output (see

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -166,7 +166,7 @@ a PREMIS event XML tree::
             </premis:eventOutcome>
         </premis:eventOutcomeInformation>
         <premis:eventDateTime>
-            2011-01-27 16:39:49
+            2011-01-27T16:39:49
         </premis:eventDateTime>
         <premis:linkingObjectIdentifier>
             <premis:linkingObjectIdentifierType>
@@ -192,7 +192,7 @@ Atom entry, so the following Atom wrapper XML tree is created::
     <entry xmlns="http://www.w3.org/2005/Atom">
         <title>PREMIS event entry for object_123</title>
         <id>PREMIS event entry for object_123</id>
-        <updated>2011-­‐01-­‐27T16:40:30Z</updated>
+        <updated>2011‐01‐27T16:40:30Z</updated>
         <author>
             <name>Object Verification Script</name>
         </author>

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -189,9 +189,9 @@ Now, in order to send the event to the Event Service, it must be wrapped in an
 Atom entry, so the following Atom wrapper XML tree is created::
 
     <entry xmlns="http://www.w3.org/2005/Atom">
-        <title>PREMIS event entry for object_123</title>
-        <id>PREMIS event entry for object_123</id>
-        <updated>2011‐01‐27T16:40:30Z</updated>
+        <title>9e42cbd3cc3b4dfc888522036bbc4491</title>
+        <id>http://localhost:9999/APP/event/9e42cbd3cc3b4dfc888522036bbc4491/</id>
+        <updated>2017-05-13T14:14:55Z</updated>
         <author>
             <name>Object Verification Script</name>
         </author>

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -129,7 +129,7 @@ Example
    :linenothreshold: 5
 
 The example below is a somewhat plausible one, using a fixity check event during a migration
-as a scenario.::
+as a scenario::
 
 
     <?xml version="1.0"?>
@@ -213,49 +213,68 @@ the XML. If it finds a valid XML PREMIS event document, it will assign the
 event an identifier, index the values and save them, and then generate a 
 return document, also wrapped in an Atom entry. It will look something like::
 
-    <entry xmlns="http://www.w3.org/2005/Atom">
-        <title>bfa2cf2c2a4f11e089b3005056935974</title>
-        <id>bfa2cf2c2a4f11e089b3-005056935974</id>
-        <updated>2017-01-27T16:40:30Z</updated>
-        <author>
-            <name>Object Verification Script</name>
-        </author>
+    <?xml version="1.0"?>
+        <entry xmlns="http://www.w3.org/2005/Atom">
+        <title>9e42cbd3cc3b4dfc888522036bbc4491</title>
+        <id>http://localhost:8000/APP/event/9e42cbd3cc3b4dfc888522036bbc4492/</id>
+        <updated>2017-03-27T09:15:31.382106-05:00</updated>
         <content type="application/xml">
-            <premis:event xmlns:premis="http://www.loc.gov/standards/premis/v1">
-                <premis:eventType>validateObject</premis:eventType>
-                <premis:linkingAgentIdentifier>
-                    <premis:linkingAgentIdentifierValue>
-                        validateObjectScript
-                    </premis:linkingAgentIdentifierValue>
-                    <premis:linkingAgentIdentifierType>
-                        Program
-                    </premis:linkingAgentIdentifierType>
-                </premis:linkingAgentIdentifier>
+            <premis:event xmlns:premis="info:lc/xmlns/premis-v2">
                 <premis:eventIdentifier>
                     <premis:eventIdentifierType>
-                        UUID
+                        http://purl.org/net/untl/vocabularies/identifier-qualifiers/#UUID
                     </premis:eventIdentifierType>
                     <premis:eventIdentifierValue>
-                        bfa2cf2c2a4f11e089b3-005056935974
+                        9e42cbd3cc3b4dfc888522036bbc4491
                     </premis:eventIdentifierValue>
                 </premis:eventIdentifier>
-                ...
+                <premis:eventType>
+                    http://purl.org/net/untl/vocabularies/preservationEvents/#fixityCheck
+                </premis:eventType>
+                <premis:eventDateTime>
+                    2017-05-13T09:14:55-05:00
+                </premis:eventDateTime>
+                <premis:eventDetail>
+                    There is no muse of philosophy, nor is there one of translation.
+                </premis:eventDetail>
+                <premis:eventOutcomeInformation>
+                    <premis:eventOutcome>
+                        http://purl.org/net/untl/vocabularies/eventOutcomes/#success
+                    </premis:eventOutcome>
+                    <premis:eventOutcomeDetail>
+                        <premis:eventOutcomeDetailNote>
+                            Total time for verification: 0:00:01.839590
+                        </premis:eventOutcomeDetailNote>
+                    </premis:eventOutcomeDetail>
+                </premis:eventOutcomeInformation>
+                <premis:linkingAgentIdentifier>
+                    <premis:linkingAgentIdentifierType>
+                        http://purl.org/net/untl/vocabularies/identifier-qualifiers/#URL
+                    </premis:linkingAgentIdentifierType>
+                    <premis:linkingAgentIdentifierValue>
+                        http://localhost:8787/agent/codaMigrationVerification
+                    </premis:linkingAgentIdentifierValue>
+                </premis:linkingAgentIdentifier>
+                <premis:linkingObjectIdentifier>
+                    <premis:linkingObjectIdentifierType>
+                        http://purl.org/net/untl/vocabularies/identifier-qualifiers/#ARK
+                    </premis:linkingObjectIdentifierType>
+                    <premis:linkingObjectIdentifierValue>
+                        ark:/67531/coda10kx
+                    </premis:linkingObjectIdentifierValue>
+                    <premis:linkingObjectRole/>
+                </premis:linkingObjectIdentifier>
             </premis:event>
         </content>
     </entry>
 
-As you can see, the identifier has been changed to a UUID, which, in this 
-case, is ``bfa2cf2c2a4f11e089b3-­‐005056935974``. This identifier is unique 
-and will be what the microservice will use to refer to that individual event 
-in the future.
-
 If the POST is successful, the updated record will be returned, along with a 
-status of "200". If the status is something else, there was an error, and 
+status of 201. If the status is something else, there was an error, and 
 the event cannot be considered to have been reliably recorded.
 
 Later, when we (or, perhaps, another script) wish to review the event to 
 find out what went wrong with the file validation, we would access it by 
 sending an HTTP GET request to 
-``/APP/event/bfa2cf2c2a4f11e089b3-005056935974``, which would return an Atom 
+``/APP/event/9e42cbd3cc3b4dfc888522036bbc4491``, which would return an Atom 
 entry containing the final event record, which we could then analyze and use 
 for whatever purposes desired.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -23,6 +23,13 @@ entry's "content" tag. There is a lot more to AtomPub than that, but for the
 purpose of this document, it is helpful to just view the Atom entry as an 
 "envelope" for the PREMIS XML.
 
+PREMIS
+------
+
+The PREMIS Event Service makes every effort to conform to the `PREMIS v.2
+specification`_. Versions 2.* of the spec are *not* backwards compatible with
+versions before the 2.0 milestone.
+
 A Note on Dates
 ---------------
 
@@ -121,49 +128,52 @@ Example
 .. highlight:: xml
    :linenothreshold: 5
 
-Imagine that we have just completed a mass server-to-server data copy, and 
-as part of that migrated data we have a directory called ``object_123/`` which 
-contains a collection of files that represents a migrated digital object. 
-This digital object conveniently enough, has the localidentifier (for our 
-system) of ``object_123``.
-
-We have a script ``validate_object`` that we can run 
-on our objects to make certain that the files match a previously stored 
-fixity digest and are intact after this migration. In this case, we wish to 
-log an event of the validation in order to properly track our actions. To begin 
-with, we run the ``validate_object`` script on our directory and wait for it to 
-run.
-
-Let's say that it runs and comes back with an 
-error: ``Validation of object_123/ failed Details: Generated sum for 
-object_123/data/pic_002.tif does not match stored value``. Obviously, we have 
-to deal with the problem at some point, but right now we just want to log an 
-event that will accurately reflect the results of the script. So, we create 
-a PREMIS event XML tree::
+The example below is a somewhat plausible one, using a fixity check event during a migration
+as a scenario.::
 
 
     <?xml version="1.0"?>
     <premis:event xmlns:premis="info:lc/xmlns/premis-v2">
         <premis:eventIdentifier>
-            <premis:eventIdentifierType>http://purl.org/net/untl/vocabularies/identifier-qualifiers/#UUID</premis:eventIdentifierType>
-            <premis:eventIdentifierValue>9e42cbd3cc3b4dfc888522036bbc4491</premis:eventIdentifierValue>
+            <premis:eventIdentifierType>
+                http://purl.org/net/untl/vocabularies/identifier-qualifiers/#UUID
+            </premis:eventIdentifierType>
+            <premis:eventIdentifierValue>
+                9e42cbd3cc3b4dfc888522036bbc4491
+            </premis:eventIdentifierValue>
         </premis:eventIdentifier>
-        <premis:eventType>http://purl.org/net/untl/vocabularies/preservationEvents/#fixityCheck</premis:eventType>
+        <premis:eventType>
+            http://purl.org/net/untl/vocabularies/preservationEvents/#fixityCheck
+        </premis:eventType>
         <premis:eventDateTime>2017-05-13T14:14:55Z</premis:eventDateTime>
-        <premis:eventDetail>There is no muse of philosophy, nor is there one of translation. </premis:eventDetail>
+        <premis:eventDetail>
+            There is no muse of philosophy, nor is there one of translation.
+        </premis:eventDetail>
         <premis:eventOutcomeInformation>
-            <premis:eventOutcome>http://purl.org/net/untl/vocabularies/eventOutcomes/#success</premis:eventOutcome>
+            <premis:eventOutcome>
+                http://purl.org/net/untl/vocabularies/eventOutcomes/#success
+            </premis:eventOutcome>
             <premis:eventOutcomeDetail>
-                <premis:eventOutcomeDetailNote>Total time for verification: 0:00:01.839590</premis:eventOutcomeDetailNote>
+                <premis:eventOutcomeDetailNote>
+                    Total time for verification: 0:00:01.839590
+                </premis:eventOutcomeDetailNote>
             </premis:eventOutcomeDetail>
         </premis:eventOutcomeInformation>
         <premis:linkingAgentIdentifier>
-            <premis:linkingAgentIdentifierType>http://purl.org/net/untl/vocabularies/identifier-qualifiers/#URL</premis:linkingAgentIdentifierType>
-            <premis:linkingAgentIdentifierValue>http://localhost:8787/agent/codaMigrationVerification</premis:linkingAgentIdentifierValue>
+            <premis:linkingAgentIdentifierType>
+                http://purl.org/net/untl/vocabularies/identifier-qualifiers/#URL
+            </premis:linkingAgentIdentifierType>
+            <premis:linkingAgentIdentifierValue>
+                http://localhost:8787/agent/codaMigrationVerification
+            </premis:linkingAgentIdentifierValue>
         </premis:linkingAgentIdentifier>
         <premis:linkingObjectIdentifier>
-            <premis:linkingObjectIdentifierType>http://purl.org/net/untl/vocabularies/identifier-qualifiers/#ARK</premis:linkingObjectIdentifierType>
-            <premis:linkingObjectIdentifierValue>ark:/67531/coda10kx</premis:linkingObjectIdentifierValue>
+            <premis:linkingObjectIdentifierType>
+                http://purl.org/net/untl/vocabularies/identifier-qualifiers/#ARK
+            </premis:linkingObjectIdentifierType>
+            <premis:linkingObjectIdentifierValue>
+                ark:/67531/coda10kx
+            </premis:linkingObjectIdentifierValue>
             <premis:linkingObjectRole/>
         </premis:linkingObjectIdentifier>
     </premis:event>

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -23,6 +23,13 @@ entry's "content" tag. There is a lot more to AtomPub than that, but for the
 purpose of this document, it is helpful to just view the Atom entry as an 
 "envelope" for the PREMIS XML.
 
+A Note on Dates
+---------------
+
+Unless otherwise noted, all datetimes mentioned below *must* be formatted
+as ``xsDateTime`` compliant strings. The output of the ``datetime.isoformat``
+method in Python is compatible.
+
 API URL Structure
 =================
 
@@ -134,48 +141,30 @@ to deal with the problem at some point, but right now we just want to log an
 event that will accurately reflect the results of the script. So, we create 
 a PREMIS event XML tree::
 
+
+    <?xml version="1.0"?>
     <premis:event xmlns:premis="info:lc/xmlns/premis-v2">
-        <premis:eventType>
-            validateObject
-        </premis:eventType>
-        <premis:linkingAgentIdentifier>
-            <premis:linkingAgentIdentifierValue>
-                validateObjectScript
-            </premis:linkingAgentIdentifierValue>
-            <premis:linkingAgentIdentifierType>
-                Program
-            </premis:linkingAgentIdentifierType>
-        </premis:linkingAgentIdentifier>
         <premis:eventIdentifier>
-            <premis:eventIdentifierType>
-                TEMP
-            </premis:eventIdentifierType>
-            <premis:eventIdentifierValue>
-                TEMP
-            </premis:eventIdentifierValue>
+            <premis:eventIdentifierType>http://purl.org/net/untl/vocabularies/identifier-qualifiers/#UUID</premis:eventIdentifierType>
+            <premis:eventIdentifierValue>9e42cbd3cc3b4dfc888522036bbc4491</premis:eventIdentifierValue>
         </premis:eventIdentifier>
-        <premis:eventDetail>Validation of object
-            object_123
-        </premis:eventDetail>
+        <premis:eventType>http://purl.org/net/untl/vocabularies/preservationEvents/#fixityCheck</premis:eventType>
+        <premis:eventDateTime>2017-05-13T14:14:55Z</premis:eventDateTime>
+        <premis:eventDetail>There is no muse of philosophy, nor is there one of translation. </premis:eventDetail>
         <premis:eventOutcomeInformation>
+            <premis:eventOutcome>http://purl.org/net/untl/vocabularies/eventOutcomes/#success</premis:eventOutcome>
             <premis:eventOutcomeDetail>
-                Generated sum for object_123/data/pic_002.tif does not match stored value
+                <premis:eventOutcomeDetailNote>Total time for verification: 0:00:01.839590</premis:eventOutcomeDetailNote>
             </premis:eventOutcomeDetail>
-            <premis:eventOutcome>
-                Failure
-            </premis:eventOutcome>
         </premis:eventOutcomeInformation>
-        <premis:eventDateTime>
-            2011-01-27T16:39:49
-        </premis:eventDateTime>
+        <premis:linkingAgentIdentifier>
+            <premis:linkingAgentIdentifierType>http://purl.org/net/untl/vocabularies/identifier-qualifiers/#URL</premis:linkingAgentIdentifierType>
+            <premis:linkingAgentIdentifierValue>http://localhost:8787/agent/codaMigrationVerification</premis:linkingAgentIdentifierValue>
+        </premis:linkingAgentIdentifier>
         <premis:linkingObjectIdentifier>
-            <premis:linkingObjectIdentifierType>
-                Local Identifier
-            </premis:linkingObjectIdentifierType>
-            <premis:linkingObjectIdentifierValue>
-                object_123
-            </premis:linkingObjectIdentifierValue>
-            <premis:linkingObjectRole />
+            <premis:linkingObjectIdentifierType>http://purl.org/net/untl/vocabularies/identifier-qualifiers/#ARK</premis:linkingObjectIdentifierType>
+            <premis:linkingObjectIdentifierValue>ark:/67531/coda10kx</premis:linkingObjectIdentifierValue>
+            <premis:linkingObjectRole/>
         </premis:linkingObjectIdentifier>
     </premis:event>
 
@@ -197,7 +186,7 @@ Atom entry, so the following Atom wrapper XML tree is created::
             <name>Object Verification Script</name>
         </author>
         <content type="application/xml">
-            <premis:event xmlns:premis="http://www.loc.gov/standards/premis/v1">
+            <premis:event xmlns:premis="info:lc/xmlns/premis-v2">
                 ...
             </premis:event>
         </content>
@@ -217,7 +206,7 @@ return document, also wrapped in an Atom entry. It will look something like::
     <entry xmlns="http://www.w3.org/2005/Atom">
         <title>bfa2cf2c2a4f11e089b3005056935974</title>
         <id>bfa2cf2c2a4f11e089b3-005056935974</id>
-        <updated>2011-01-27T16:40:30Z</updated>
+        <updated>2017-01-27T16:40:30Z</updated>
         <author>
             <name>Object Verification Script</name>
         </author>

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -11,23 +11,26 @@ Project Structure
 The PREMIS Event Service is structured as a common Python project, providing a
 Python package named `premis_event_service` which is a Django app::
 
-    premis_event_service/ # The Django app itself. Technically a Python package.
-        admin.py          ## Customizes the Django admin interface
-        coda/             ## Some supporting modules we need for some tasks
-            anvl.py
-            bagatom.py
-            __init__.py   ### Marks this directory as a valid Python package
-            util.py
-        forms.py          ## Form processing code
-        helpy.py
-        __init__.py       ## Marks this directory as a valid Python package
-        models.py         ## Database model definitions
-        populator.py
-        presentation.py
-        settings.py       ## Wrapper for project settings file with custom defaults
-        templates/        ## HTML templates
-        urls.py           ## URL routing patterns
-        views.py          ## View generation code
+    premis_event_service/
+    ├── admin.py          ## Customizes the Django admin interface
+    ├── forms.py          ## Form definitions and validation code
+    ├── __init__.py       ## Makes this directory a Python package
+    ├── migrations        ## Django database migrations
+    │   ├── 0001_initial.py
+    │   ├── 0002_add_event_ordinal.py
+    │   └── __init__.py
+    ├── models.py         ## Data models, using Django ORM
+    ├── presentation.py   ## Business logic
+    ├── settings.py       ## App-specific settings
+    ├── templates
+    │   └── premis_event_service
+    │       ├── agent.html
+    │       ├── base.html
+    │       ├── event.html
+    │       ├── recent_event_list.html
+    │       └── search.html
+    ├── urls.py           ## App-specific url patterns/routes
+    └── views.py          ## Route handlers which generate human- and machine-readable views
 
 If you're not sure where to look for something, `urls.py` is usually the best
 place to start.  There you'll find a list of every URL pattern handled by the

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -33,6 +33,7 @@ Install
 1. Install the package. ::
 
     $ pip install git+https://github.com/unt-libraries/django-premis-event-service@v1.2.2
+    $ # check https://github.com/unt-libraries/django-premis-event-service/releases for the latest  release
 
 
 2. Add ``premis_event_service`` to your ``INSTALLED_APPS``. Be sure to add ``django.contrib.admin`` if it is not already present. ::

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -33,8 +33,7 @@ Install
 1. Install the package. ::
 
     $ pip install git+https://github.com/unt-libraries/django-premis-event-service@v1.2.2
-    $ # check https://github.com/unt-libraries/django-premis-event-service/releases for the latest  release
-
+    $ # check https://github.com/unt-libraries/django-premis-event-service/releases for the latest release
 
 2. Add ``premis_event_service`` to your ``INSTALLED_APPS``. Be sure to add ``django.contrib.admin`` if it is not already present. ::
 

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -114,3 +114,5 @@ As you can see from the above example, the agent's identifier above
 corresponds with the agent in the event example. You are able to create and 
 register agents through the administrative panel on the PREMIS service; 
 see the :doc:`administration` section to learn how.
+
+Note that there is no schematic relationship between Agent objects and Event objects in the application's database tables. Events may be linked to any Agent identifier and are not limited in any way to Agent items created in administrative interface.

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -110,5 +110,5 @@ looks like the following::
 
 As you can see from the above example, the agent's identifier above 
 corresponds with the agent in the event example. You are able to create and 
-register agents through the administrative panel on the PREMIS microservice; 
+register agents through the administrative panel on the PREMIS service; 
 see the :doc:`administration` section to learn how.

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -11,50 +11,52 @@ Events
 
 A standard PREMIS event encoded as XML looks something like the following::
 
+    <?xml version="1.0"?>
     <premis:event xmlns:premis="info:lc/xmlns/premis-v2">
-        <premis:eventType>
-            http://purl.org/net/meta/vocabularies/preservationEvents/#MigrateSuccess
-        </premis:eventType>
-        <premis:linkingAgentIdentifier>
-            <premis:linkingAgentIdentifierValue>
-                http://metaarchive.org/agent/metaMigrateSuccess
-            </premis:linkingAgentIdentifierValue>
-            <premis:linkingAgentIdentifierType>
-                http://purl.org/net/meta/vocabularies/identifier-qualifiers/#URL
-            </premis:linkingAgentIdentifierType>
-        </premis:linkingAgentIdentifier>
         <premis:eventIdentifier>
             <premis:eventIdentifierType>
-                http://purl.org/net/meta/vocabularies/identifier-qualifiers/#UUID
+                http://purl.org/net/untl/vocabularies/identifier-qualifiers/#UUID
             </premis:eventIdentifierType>
             <premis:eventIdentifierValue>
-                e8ee3b1a8c9e4a5daf0a1e0446383d90
+                9e42cbd3cc3b4dfc888522036bbc4491
             </premis:eventIdentifierValue>
         </premis:eventIdentifier>
+        <premis:eventType>
+            http://purl.org/net/untl/vocabularies/preservationEvents/#fixityCheck
+        </premis:eventType>
+        <premis:eventDateTime>2017-05-13T14:14:55Z</premis:eventDateTime>
         <premis:eventDetail>
-            Verification of data at /data3/meta-r1-003_dropbox/meta106w
+            There is no muse of philosophy, nor is there one of translation.
         </premis:eventDetail>
         <premis:eventOutcomeInformation>
-            <premis:eventOutcomeDetail>
-                Checking content after cache server migration
-            </premis:eventOutcomeDetail>
             <premis:eventOutcome>
-                http://purl.org/net/meta/vocabularies/eventOutcomes/#success
+                http://purl.org/net/untl/vocabularies/eventOutcomes/#success
             </premis:eventOutcome>
+            <premis:eventOutcomeDetail>
+                <premis:eventOutcomeDetailNote>
+                    Total time for verification: 0:00:01.839590
+                </premis:eventOutcomeDetailNote>
+            </premis:eventOutcomeDetail>
         </premis:eventOutcomeInformation>
-        <premis:eventDateTime>
-            2011-01-25 16:39:49
-        </premis:eventDateTime>
+        <premis:linkingAgentIdentifier>
+            <premis:linkingAgentIdentifierType>
+                http://purl.org/net/untl/vocabularies/identifier-qualifiers/#URL
+            </premis:linkingAgentIdentifierType>
+            <premis:linkingAgentIdentifierValue>
+                http://localhost:8787/agent/codaMigrationVerification
+            </premis:linkingAgentIdentifierValue>
+        </premis:linkingAgentIdentifier>
         <premis:linkingObjectIdentifier>
             <premis:linkingObjectIdentifierType>
-                http://purl.org/net/meta/vocabularies/identifier-qualifiers/#ARK
+                http://purl.org/net/untl/vocabularies/identifier-qualifiers/#ARK
             </premis:linkingObjectIdentifierType>
             <premis:linkingObjectIdentifierValue>
-                ark:/67531/meta106w
+                ark:/67531/coda10kx
             </premis:linkingObjectIdentifierValue>
             <premis:linkingObjectRole/>
         </premis:linkingObjectIdentifier>
     </premis:event>
+
 
 This is a lot at first glance, but the pieces are more or less logical. The 
 relevant things that a given PREMIS event record keeps track of are the 
@@ -95,15 +97,15 @@ looks like the following::
     <?xml version="1.0"?>
     <premis:agent xmlns:premis="info:lc/xmlns/premis-v2">
         <premis:agentIdentifier>
-            <premis:agentIdentifierValue>
-                MigrateSuccess
-            </premis:agentIdentifierValue>
             <premis:agentIdentifierType>
-                FDsys:agent
+                http://purl.org/net/untl/vocabularies/identifier-qualifiers/#URL
             </premis:agentIdentifierType>
+            <premis:agentIdentifierValue>
+                http://localhost:8787/agent/codaMigrationVerification
+            </premis:agentIdentifierValue>
         </premis:agentIdentifier>
         <premis:agentName>
-            http://institution.edu/agent/metaMigrateSuccess
+            codaMigrationVerification
         </premis:agentName>
         <premis:agentType>softw</premis:agentType>
     </premis:agent>

--- a/tox.mysql.ini
+++ b/tox.mysql.ini
@@ -11,7 +11,7 @@ exclude = *migrations/*
 
 [tox]
 envlist=
-    py27-django{17,18,19}
+    py27-django{17,18,19,110,master}
     flake8
 
 [testenv]
@@ -21,6 +21,7 @@ deps =
     django17: Django~=1.7.0
     django18: Django~=1.8.0
     django19: Django~=1.9.0
+    django110: Django~=1.10.0
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 commands = py.test
 setenv =
@@ -30,3 +31,7 @@ setenv =
 skip_install = True
 deps= flake8
 commands= flake8 setup.py premis_event_service tests
+
+[testenv:py27-djangomaster]
+ignore_outcome = True
+ignore_errors = True


### PR DESCRIPTION
I also updated the `tox` config for the Docker container, as I noticed it only during the process of updating these docs.

If you don't want to build them locally, you can view rendered docs from this branch at:

http://premis-event-service.readthedocs.io/en/update-docs-evtxml/

@ldko @somexpert 

