### PR TITLE
Fix totalResults in event search JSON

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -770,7 +770,7 @@ class TestJsonEventSearch:
         assert response.get('Content-Type') == self.CONTENT_TYPE
 
     def test_no_results(self, rf):
-        """Check that response content when there are no Events
+        """Check the response content when there are no Events
         in the database.
         """
         request = rf.get('/')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -776,7 +776,9 @@ class TestJsonEventSearch:
         request = rf.get('/')
         response = views.json_event_search(request)
         data = json.loads(response.content)
-        assert len(data) == 0
+        assert data.get('feed') is not None
+        assert data.get('feed', {}).get('entry') is not None
+        assert not len(data.get('feed', {}).get('entry'))
         assert response.status_code == 200
 
     def test_results_per_page(self, rf):


### PR DESCRIPTION
Uses the correct value for result sets in event search JSON. Fixes return value for empty result sets. Adjusts page number for the same. @ldko @somexpert 