### PR TITLE
Set up for a release of 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.2.5
+-----
+
+* Removed bare excepts for flake8 ([#89](
+https://github.com/unt-libraries/django-premis-event-service/pull/89))
+
 1.2.4
 -----
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -32,7 +32,7 @@ Install
 
 1. Install the package. ::
 
-    $ pip install git+https://github.com/unt-libraries/django-premis-event-service@1.2.4
+    $ pip install git+https://github.com/unt-libraries/django-premis-event-service@1.2.5
     $ # check https://github.com/unt-libraries/django-premis-event-service/releases for the latest release
 
 2. Add ``premis_event_service`` to your ``INSTALLED_APPS``. Be sure to add ``django.contrib.admin`` if it is not already present. ::

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
 
 setup(
     name="django-premis-event-service",
-    version="1.2.4",
+    version="1.2.5",
     packages=find_packages(exclude=["tests", ]),
     include_package_data=True,
     license="BSD",


### PR DESCRIPTION
Since we had a tag on 1.2.4 already, I am making a 1.2.5 to cleanly get everything up-to-date in a release.
@somexpert 