### PR TITLE
Be more specific with base Python image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # vim: set ft=conf
-FROM python:2.7
+FROM python:2.7-stretch
 
 RUN echo "US/Central" > /etc/timezone
 RUN dpkg-reconfigure -f noninteractive tzdata


### PR DESCRIPTION
This resolves the docker build issues surrounding the newer `buster` base image for Python 2.7, which is the default when the tag is just `python:2.7`