### PR TITLE
Exception has no attribute message in py3

### DIFF
--- a/premis_event_service/views.py
+++ b/premis_event_service/views.py
@@ -507,7 +507,7 @@ def app_event(request, identifier=None):
             )
         except DuplicateEventError as e:
             return HttpResponse(
-                "An event with id='{}' exists.".format(e.message),
+                "An event with id='{}' exists.".format(e),
                 status=409, content_type="text/plain"
             )
         if type(newEvent) == HttpResponse:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -459,6 +459,20 @@ class TestAppEvent:
         views.app_event(request)
         assert models.Event.objects.count() == 1
 
+    def test_post_DuplicateEventError(self, event_xml, rf):
+        request = rf.post(
+            '/',
+            event_xml.entry_xml,
+            content_type='application/xml',
+            HTTP_HOST='example.com')
+
+        # Try to POST the same event twice.
+        views.app_event(request)
+        response = views.app_event(request)
+        assert response.status_code == 409
+        expected_response = "An event with id='{}' exists.".format(event_xml.identifier)
+        assert expected_response in response.content.decode('utf-8')
+
     def test_put_returns_ok(self, event_xml, rf):
         identifier = event_xml.identifier
         factories.EventFactory.create(event_identifier=identifier)


### PR DESCRIPTION
Playing with a Python 3 coda instance, I triggered a `'DuplicateEventError' object has no attribute 'message'` when posting an event twice. `Exception`, from which `DuplicateEventError` inherits, no longer has a `message` attribute in Python 3.

ping @somexpert @madhulika95b 