### PR TITLE
Avoid pipenv install --system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -qq && apt-get install -y mysql-client netcat
 
 RUN pip install -U pip setuptools
 RUN pip install pipenv
-RUN pipenv install --dev --system --deploy --ignore-pipfile
+RUN pipenv install --dev --deploy --ignore-pipfile
 
 ADD wait-for-mysqld.sh /wait-for-mysqld.sh
 ADD appstart.sh /appstart.sh

--- a/appstart.sh
+++ b/appstart.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 /wait-for-mysqld.sh
 echo "Migrate..."
-python manage.py migrate --settings=tests.settings
+pipenv run python manage.py migrate --settings=tests.settings
 echo "Start app..."
-python manage.py runserver 0.0.0.0:80 --settings=tests.settings
-
+pipenv run python manage.py runserver 0.0.0.0:80 --settings=tests.settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
         environment:
             - DJANGO_SETTINGS_MODULE=tests.settings
             - PES_BACKEND=mysql
-        entrypoint: tox -c /app/tox.ini
+        entrypoint: pipenv run tox -c /app/tox.ini --skip-missing-interpreters true
         links:
             - db
         depends_on:
@@ -48,7 +48,7 @@ services:
         environment:
             - DJANGO_SETTINGS_MODULE=tests.settings
             - PES_BACKEND=mysql
-        entrypoint: /app/manage.py
+        entrypoint: pipenv run /app/manage.py
         links:
             - db
         depends_on:


### PR DESCRIPTION
Per current recommendation of `pipenv` [don't use `--system` with `pipenv install` in Docker context](https://github.com/pypa/pipenv/pull/2762). Hopefully this takes care of the `ModuleNotFoundError: No module named 'codalib'` that was happening when running in Docker. This also adds `--skip-missing-interpreters true` to calling `tox` in Docker, since we only have Python 3.7 installed.